### PR TITLE
Register proxy HTTP clients, install fetch proxy

### DIFF
--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -204,6 +204,8 @@ export class WorkbenchPanel {
             command: 'apiResponse',
             ...response,
           });
+        } else {
+          log.error('apiRequest received but _apiProxyService is not initialized');
         }
         return;
 

--- a/webview/src/WorkbenchRuntime.ts
+++ b/webview/src/WorkbenchRuntime.ts
@@ -24,6 +24,7 @@ import { ExtensionManager } from './ExtensionManager';
 import { WebPartManager } from './WebPartManager';
 import type { IAppHandlers } from './components/App';
 import { SpfxContext, ThemeProvider } from './mocks';
+import { registerProxyHttpClients } from './proxy';
 import type { IVsCodeApi, IWorkbenchConfig } from './types';
 
 export class WorkbenchRuntime {
@@ -130,6 +131,12 @@ export class WorkbenchRuntime {
       // Initialize SPFx mocks
       initializeSpfxMocks();
       this.log.debug('SPFx mocks initialized');
+
+      // Override AMD HTTP client stubs with proxy clients (if proxy enabled)
+      if (this.config.proxyEnabled !== false) {
+        registerProxyHttpClients();
+        this.log.debug('Proxy HTTP clients registered in AMD modules');
+      }
 
       // Update status
       this.updateStatus(`Connecting to serve at ${this.config.serveUrl}...`);
@@ -464,6 +471,12 @@ export class WorkbenchRuntime {
     }
 
     initializeSpfxMocks();
+
+    // Override AMD HTTP client stubs with proxy clients (if proxy enabled)
+    if (this.config.proxyEnabled !== false) {
+      registerProxyHttpClients();
+      this.log.debug('Proxy HTTP clients registered in AMD modules (live reload)');
+    }
 
     const serveOrigin = new URL(this.config.serveUrl).origin;
     document.querySelectorAll('script[src]').forEach((script) => {

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -10,7 +10,7 @@ import type { ITheme, IThemeGroup } from '@spfx-local-workbench/shared';
 import { WorkbenchRuntime } from './WorkbenchRuntime';
 import { App, IAppHandlers } from './components/App';
 import { StatusBarThemePicker } from './components/StatusBarThemePicker';
-import { initializeProxyBridge } from './proxy';
+import { initializeProxyBridge, installFetchProxy } from './proxy';
 import './styles/global.css';
 
 const log = logger.createChild('Main');
@@ -39,6 +39,7 @@ function initialize() {
     // tools like Dev Proxy can intercept network traffic.
     if (config.proxyEnabled !== false) {
       initializeProxyBridge(vscodeApi);
+      installFetchProxy();
     }
 
     // Create the workbench runtime

--- a/webview/src/proxy/ProxyBridge.ts
+++ b/webview/src/proxy/ProxyBridge.ts
@@ -60,6 +60,7 @@ class ProxyBridge {
   // Initialize with the VS Code API handle and start listening for responses
   initialize(vscodeApi: IVsCodeApi): void {
     if (this._initialized) {
+      console.log('[ProxyBridge] Already initialized');
       return;
     }
     this._vscodeApi = vscodeApi;
@@ -84,6 +85,7 @@ class ProxyBridge {
   ): Promise<IProxyResponse> {
     if (!this._vscodeApi) {
       // If bridge not initialized, return an empty mock (graceful fallback)
+      console.warn('[ProxyBridge] NOT INITIALIZED - returning fallback response for:', method, url);
       return Promise.resolve({
         id: 'fallback',
         status: 200,

--- a/webview/src/proxy/ProxySPHttpClient.ts
+++ b/webview/src/proxy/ProxySPHttpClient.ts
@@ -3,7 +3,7 @@ import type { ApiClientType } from './ProxyBridge';
 import { ProxyHttpClient } from './ProxyHttpClient';
 
 // Proxy-aware SPHttpClient replacement.
-// Tags all requests with clientType 'spHttp' so mock rules can target harePoint REST API calls specifically.
+// Tags all requests with clientType 'spHttp' so mock rules can target SharePoint REST API calls specifically.
 export class ProxySPHttpClient extends ProxyHttpClient {
   static configurations = { v1: {} };
 

--- a/webview/src/proxy/index.ts
+++ b/webview/src/proxy/index.ts
@@ -10,3 +10,4 @@ export { ProxySPHttpClient } from './ProxySPHttpClient';
 export { ProxyAadHttpClient } from './ProxyAadHttpClient';
 export { PassthroughHttpClient } from './PassthroughHttpClient';
 export { installFetchProxy, uninstallFetchProxy } from './ProxyFetchClient';
+export { registerProxyHttpClients } from './registerProxyHttpClients';

--- a/webview/src/proxy/registerProxyHttpClients.ts
+++ b/webview/src/proxy/registerProxyHttpClients.ts
@@ -1,0 +1,26 @@
+// Register Proxy HTTP Clients in AMD Module System
+//
+// Overrides the stub HTTP client classes in the AMD module registry with the actual
+// proxy-aware implementations so web parts that import classes from '@microsoft/sp-http'
+// get the proxy clients instead of the stubs.
+
+import { ProxyAadHttpClient } from './ProxyAadHttpClient';
+import { ProxyHttpClient } from './ProxyHttpClient';
+import { ProxySPHttpClient } from './ProxySPHttpClient';
+
+export function registerProxyHttpClients(): void {
+  if (!window.__amdModules) {
+    console.warn('[registerProxyHttpClients] __amdModules not initialized');
+    return;
+  }
+
+  // Override the stub classes with proxy-aware implementations
+  window.__amdModules['@microsoft/sp-http'] = {
+    HttpClient: ProxyHttpClient,
+    SPHttpClient: ProxySPHttpClient,
+    AadHttpClient: ProxyAadHttpClient,
+    SPHttpClientConfiguration: {},
+    HttpClientConfiguration: {},
+    AadHttpClientConfiguration: {},
+  };
+}


### PR DESCRIPTION
This was needed to make PnPjs calls work. Wowee n such!

Add registration of proxy-aware HTTP clients for AMD modules and wire up fetch proxy support. Introduces registerProxyHttpClients.ts and exports it from the proxy index, calls registerProxyHttpClients() during runtime initialization and live-reload (when proxyEnabled !== false), and calls installFetchProxy() from main startup. Also adds additional logging and error handling: console logs in ProxyBridge for initialization/fallback, an error log in WorkbenchPanel when api proxy isn't initialized, and a small typo fix in ProxySPHttpClient (SharePoint). These changes enable Dev Proxy integration for SPFx workbench HTTP traffic and improve diagnostics.