### PR TITLE
Mock tweaks

### DIFF
--- a/MOCK-DATA.md
+++ b/MOCK-DATA.md
@@ -26,6 +26,7 @@ The SPFx Local Workbench includes tools to help you **generate and populate** yo
     - [What It Generates](#what-it-generates-1)
     - [Typical Workflow](#typical-workflow)
   - [How Rules Are Merged](#how-rules-are-merged)
+  - [Rule Names](#rule-names)
   - [Disabled Rules](#disabled-rules)
   - [URL Matching Behavior](#url-matching-behavior)
   - [All Commands](#all-commands)
@@ -161,6 +162,7 @@ This keeps your `api-mocks.json` small and lets you manage large response payloa
 Parse a `.csv` file and use its rows as the JSON response body for a mock rule. This is useful when you have tabular data in a spreadsheet that you want to serve as a mock API response.
 
 <!-- markdownlint-disable MD024 -->
+
 ### Workflow
 
 1. **Pick a CSV file** — the first row is treated as column headers
@@ -262,6 +264,27 @@ After generation, the file is opened in the editor so you can review and adjust 
 
 ---
 
+## Rule Names
+
+Rules can include an optional `"name"` property to provide a friendly identifier. When a request matches a rule with a name, the name is displayed in the logs instead of the URL pattern:
+
+```json
+{
+  "name": "Get site lists",
+  "match": { "url": "/_api/web/lists", "method": "GET" },
+  "response": { "status": 200, "body": { "value": [] } }
+},
+{
+  "name": "List items endpoint",
+  "match": { "url": "/_api/web/lists/getbytitle('*')/items", "urlPattern": true },
+  "response": { "status": 200, "body": { "d": { "results": [] } } }
+}
+```
+
+This is especially useful when working with glob patterns or long URLs, making it easier to identify which rule matched in the proxy logs.
+
+---
+
 ## Disabled Rules
 
 Rules can include a `"disabled": true` property. Disabled rules are **skipped** during matching, allowing you to keep multiple response variants for the same URL and toggle between them:
@@ -301,12 +324,12 @@ For **glob pattern** rules (`"urlPattern": true`), first match wins — specific
 
 ## All Commands
 
-| Command | Description |
-| --- | --- |
-| `SPFx Mock Data: Scaffold API Mock Configuration` | Create a starter `api-mocks.json` file |
-| `SPFx Mock Data: Generate Status Code Stubs` | Generate rules for multiple status codes via wizard |
-| `SPFx Mock Data: Import JSON File as Mock` | Import a JSON file as a mock response body |
-| `SPFx Mock Data: Import CSV File as Mock` | Parse a CSV file into a JSON mock response |
-| `SPFx Mock Data: Record Requests & Generate Rules` | Capture unmatched requests and generate stub rules |
+| Command                                            | Description                                         |
+| -------------------------------------------------- | --------------------------------------------------- |
+| `SPFx Mock Data: Scaffold API Mock Configuration`  | Create a starter `api-mocks.json` file              |
+| `SPFx Mock Data: Generate Status Code Stubs`       | Generate rules for multiple status codes via wizard |
+| `SPFx Mock Data: Import JSON File as Mock`         | Import a JSON file as a mock response body          |
+| `SPFx Mock Data: Import CSV File as Mock`          | Parse a CSV file into a JSON mock response          |
+| `SPFx Mock Data: Record Requests & Generate Rules` | Capture unmatched requests and generate stub rules  |
 
 All commands are also accessible from the **Command Palette** (`Ctrl+Shift+P`).

--- a/MOCK-DATA.md
+++ b/MOCK-DATA.md
@@ -331,5 +331,6 @@ For **glob pattern** rules (`"urlPattern": true`), first match wins — specific
 | `SPFx Mock Data: Import JSON File as Mock`         | Import a JSON file as a mock response body          |
 | `SPFx Mock Data: Import CSV File as Mock`          | Parse a CSV file into a JSON mock response          |
 | `SPFx Mock Data: Record Requests & Generate Rules` | Capture unmatched requests and generate stub rules  |
+| `SPFx Local Workbench: Show API Proxy Log`         | Open the API proxy log                              |
 
 All commands are also accessible from the **Command Palette** (`Ctrl+Shift+P`).

--- a/PROXY.md
+++ b/PROXY.md
@@ -17,13 +17,14 @@ The workbench replaces the real SPFx HTTP clients with proxy-aware versions:
 | `SPHttpClient`  | `ProxySPHttpClient`  | `spHttp`        |
 | `HttpClient`    | `ProxyHttpClient`    | `http`          |
 | `AadHttpClient` | `ProxyAadHttpClient` | `aadHttp`       |
+| global `fetch()`| `ProxyFetchClient`   | `fetch`         |
 
 Each proxy class exposes the same methods your web parts already use — `get()`, `post()`, `put()`, `patch()`, `delete()`, `fetch()`, etc. — so **no code changes** are required in your web part.
 
 Under the hood, every method call:
 
 1. Serializes the request (URL, method, headers, body) into a plain object.
-2. Tags it with a **client type** (`spHttp`, `http`, or `aadHttp`) so mock rules can distinguish between SharePoint REST calls, generic HTTP calls, and AAD-protected API calls.
+2. Tags it with a **client type** (`spHttp`, `http`, `aadHttp`, or `fetch`) so mock rules can distinguish between SharePoint REST calls, generic HTTP calls, AAD-protected API calls, and global `fetch()` calls.
 3. Sends it through the **Proxy Bridge**.
 
 ### 2. Proxy Bridge (Webview ↔ Extension Host)

--- a/PROXY.md
+++ b/PROXY.md
@@ -12,11 +12,11 @@ The proxy system has three layers:
 
 The workbench replaces the real SPFx HTTP clients with proxy-aware versions:
 
-| Real SPFx Class | Proxy Replacement | Client Type Tag |
-| --- | --- | --- |
-| `SPHttpClient` | `ProxySPHttpClient` | `spHttp` |
-| `HttpClient` | `ProxyHttpClient` | `http` |
-| `AadHttpClient` | `ProxyAadHttpClient` | `aadHttp` |
+| Real SPFx Class | Proxy Replacement    | Client Type Tag |
+| --------------- | -------------------- | --------------- |
+| `SPHttpClient`  | `ProxySPHttpClient`  | `spHttp`        |
+| `HttpClient`    | `ProxyHttpClient`    | `http`          |
+| `AadHttpClient` | `ProxyAadHttpClient` | `aadHttp`       |
 
 Each proxy class exposes the same methods your web parts already use — `get()`, `post()`, `put()`, `patch()`, `delete()`, `fetch()`, etc. — so **no code changes** are required in your web part.
 
@@ -128,10 +128,10 @@ Create a file at `.spfx-workbench/api-mocks.json` in your project root (or run t
 
 ### 2. Configuration File Structure
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `delay` | `number` | Global default delay (ms) applied to all responses unless overridden per-rule. |
-| `rules` | `IMockRule[]` | Array of mock rules. Evaluated in order; first match wins. |
+| Property | Type          | Description                                                                    |
+| -------- | ------------- | ------------------------------------------------------------------------------ |
+| `delay`  | `number`      | Global default delay (ms) applied to all responses unless overridden per-rule. |
+| `rules`  | `IMockRule[]` | Array of mock rules. Evaluated in order; first match wins.                     |
 
 ### 3. Mock Rule Structure
 
@@ -139,24 +139,31 @@ Each rule has a **match** section and a **response** section:
 
 #### Match
 
-| Property | Type | Required | Description |
-| --- | --- | --- | --- |
-| `url` | `string` | Yes | URL substring to match against the request URL. |
-| `method` | `string` | No | HTTP method filter (`GET`, `POST`, etc.). If omitted, matches any method. |
-| `clientType` | `string` | No | Restrict to a specific client: `spHttp`, `http`, or `aadHttp`. |
-| `urlPattern` | `boolean` | No | When `true`, `url` is treated as a glob pattern instead of a substring. |
+| Property     | Type      | Required | Description                                                               |
+| ------------ | --------- | -------- | ------------------------------------------------------------------------- |
+| `url`        | `string`  | Yes      | URL substring to match against the request URL.                           |
+| `method`     | `string`  | No       | HTTP method filter (`GET`, `POST`, etc.). If omitted, matches any method. |
+| `clientType` | `string`  | No       | Restrict to a specific client: `spHttp`, `http`, or `aadHttp`.            |
+| `urlPattern` | `boolean` | No       | When `true`, `url` is treated as a glob pattern instead of a substring.   |
 
 #### Response
 
-| Property | Type | Required | Description |
-| --- | --- | --- | --- |
-| `status` | `number` | Yes | HTTP status code to return (e.g., `200`, `404`, `500`). |
-| `headers` | `object` | No | Response headers. Defaults to `{ "content-type": "application/json" }`. |
-| `body` | `any` | No | Inline response body. Can be an object (auto-serialized to JSON) or a string. |
-| `bodyFile` | `string` | No | Path to a file containing the response body (relative to workspace root). Use this for large responses. |
-| `delay` | `number` | No | Per-rule delay in milliseconds (overrides the global `delay`). |
+| Property   | Type     | Required | Description                                                                                             |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `status`   | `number` | Yes      | HTTP status code to return (e.g., `200`, `404`, `500`).                                                 |
+| `headers`  | `object` | No       | Response headers. Defaults to `{ "content-type": "application/json" }`.                                 |
+| `body`     | `any`    | No       | Inline response body. Can be an object (auto-serialized to JSON) or a string.                           |
+| `bodyFile` | `string` | No       | Path to a file containing the response body (relative to workspace root). Use this for large responses. |
+| `delay`    | `number` | No       | Per-rule delay in milliseconds (overrides the global `delay`).                                          |
 
 > **Note:** `body` and `bodyFile` are mutually exclusive. If both are specified, `bodyFile` takes precedence.
+
+#### Top-Level Rule Properties
+
+| Property   | Type      | Required | Description                                                                                                                                                                |
+| ---------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | `string`  | No       | Optional friendly name for the rule. When provided, this name is displayed in logs instead of the URL pattern. Helps identify rules when debugging or monitoring requests. |
+| `disabled` | `boolean` | No       | When `true`, the rule is skipped during matching. Useful for keeping multiple response variants for testing different scenarios.                                           |
 
 ## Examples
 
@@ -208,6 +215,32 @@ Only matches POST requests made through `SPHttpClient`:
   }
 }
 ```
+
+### Named rule for easier debugging
+
+Add a friendly `name` to identify rules in logs:
+
+```json
+{
+  "name": "Get Documents library items",
+  "match": {
+    "url": "/_api/web/lists/getbytitle('Documents')/items"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "d": {
+        "results": [
+          { "Id": 1, "Title": "Report.docx" },
+          { "Id": 2, "Title": "Presentation.pptx" }
+        ]
+      }
+    }
+  }
+}
+```
+
+When this rule matches, the logs will show `Matched rule: Get Documents library items` instead of the full URL.
 
 ### Respond with an external file
 
@@ -277,13 +310,13 @@ Target calls made through `AadHttpClient` to a custom backend:
 
 You can customize proxy behavior through VS Code settings:
 
-| Setting | Default | Description |
-| --- | --- | --- |
-| `spfxLocalWorkbench.proxy.enabled` | `true` | Enable or disable the API proxy system. When disabled, HTTP client calls make real `fetch()` requests instead of routing through the mock rule engine, allowing external tools like Dev Proxy to handle them. **Requires closing and reopening the workbench to take effect.** |
-| `spfxLocalWorkbench.proxy.mockFile` | `.spfx-workbench/api-mocks.json` | Path to the mock config file (relative to workspace root). |
-| `spfxLocalWorkbench.proxy.defaultDelay` | `0` | Default delay (ms) for all mock responses. |
-| `spfxLocalWorkbench.proxy.fallbackStatus` | `404` | HTTP status returned when no mock rule matches a request. |
-| `spfxLocalWorkbench.proxy.logRequests` | `true` | Log all proxied requests to the **SPFx API Proxy** output channel. |
+| Setting                                   | Default                          | Description                                                                                                                                                                                                                                                                    |
+| ----------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `spfxLocalWorkbench.proxy.enabled`        | `true`                           | Enable or disable the API proxy system. When disabled, HTTP client calls make real `fetch()` requests instead of routing through the mock rule engine, allowing external tools like Dev Proxy to handle them. **Requires closing and reopening the workbench to take effect.** |
+| `spfxLocalWorkbench.proxy.mockFile`       | `.spfx-workbench/api-mocks.json` | Path to the mock config file (relative to workspace root).                                                                                                                                                                                                                     |
+| `spfxLocalWorkbench.proxy.defaultDelay`   | `0`                              | Default delay (ms) for all mock responses.                                                                                                                                                                                                                                     |
+| `spfxLocalWorkbench.proxy.fallbackStatus` | `404`                            | HTTP status returned when no mock rule matches a request.                                                                                                                                                                                                                      |
+| `spfxLocalWorkbench.proxy.logRequests`    | `true`                           | Log all proxied requests to the **SPFx API Proxy** output channel.                                                                                                                                                                                                             |
 
 ## Viewing Proxy Logs
 
@@ -293,13 +326,13 @@ All proxied requests are logged to the **SPFx API Proxy** output channel (access
 
 The `MockProxyResponse` returned to your web part mirrors the SPFx `SPHttpClientResponse` interface:
 
-| Property / Method | Description |
-| --- | --- |
-| `.ok` | `true` if status is 200–299. |
-| `.status` | The HTTP status code. |
-| `.headers` | Response headers object. |
-| `.json()` | Returns a `Promise` that resolves to the parsed JSON body. |
-| `.text()` | Returns a `Promise` that resolves to the raw string body. |
+| Property / Method | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `.ok`             | `true` if status is 200–299.                               |
+| `.status`         | The HTTP status code.                                      |
+| `.headers`        | Response headers object.                                   |
+| `.json()`         | Returns a `Promise` that resolves to the parsed JSON body. |
+| `.text()`         | Returns a `Promise` that resolves to the raw string body.  |
 
 Your existing web part code like `response.json().then(data => ...)` works without modification.
 

--- a/package.json
+++ b/package.json
@@ -176,13 +176,12 @@
         "title": "%command.spfx-local-workbench.recordRequests.title%",
         "category": "SPFx Mock Data",
         "icon": "$(record)"
-      }
-    ],
-    "submenus": [
+      },
       {
-        "id": "spfx-local-workbench.mockData",
-        "label": "%submenu.spfx-local-workbench.mockData.label%",
-        "icon": "$(database)"
+        "command": "spfx-local-workbench.showApiProxyLog",
+        "title": "%command.spfx-local-workbench.showApiProxyLog.title%",
+        "category": "SPFx Mock Data",
+        "icon": "$(output)"
       }
     ],
     "menus": {
@@ -231,28 +230,6 @@
           "command": "spfx-local-workbench.discardComponents",
           "when": "spfxLocalWorkbench.isWorkbench",
           "group": "1_overflow@1"
-        }
-      ],
-      "spfx-local-workbench.mockData": [
-        {
-          "command": "spfx-local-workbench.scaffoldMockConfig",
-          "group": "1_scaffold"
-        },
-        {
-          "command": "spfx-local-workbench.generateStatusStubs",
-          "group": "2_generate"
-        },
-        {
-          "command": "spfx-local-workbench.importJsonMock",
-          "group": "3_import"
-        },
-        {
-          "command": "spfx-local-workbench.importCsvMock",
-          "group": "3_import"
-        },
-        {
-          "command": "spfx-local-workbench.recordRequests",
-          "group": "4_record"
         }
       ]
     },

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -24,11 +24,10 @@
   "command.spfx-local-workbench.importJsonMock.title": "Importer un fichier JSON en tant que mock",
   "command.spfx-local-workbench.importCsvMock.title": "Importer un fichier CSV en tant que mock",
   "command.spfx-local-workbench.recordRequests.title": "Enregistrer les requêtes et générer des règles",
+  "command.spfx-local-workbench.showApiProxyLog.title": "Afficher le journal du proxy API",
   "command.spfx-local-workbench.switchToDisplayMode.title": "Passer en mode Aperçu",
   "command.spfx-local-workbench.switchToEditMode.title": "Passer en mode Édition",
   "command.spfx-local-workbench.discardComponents.title": "Abandonner les composants (réinitialiser le workbench)",
-
-  "submenu.spfx-local-workbench.mockData.label": "Données simulées",
 
   "configuration.spfxLocalWorkbench.group.general.title": "Général",
   "configuration.spfxLocalWorkbench.serveUrl.description": "L'URL où le service SPFx est en cours d'exécution",

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,11 +25,10 @@
   "command.spfx-local-workbench.importJsonMock.title": "Import JSON File as Mock",
   "command.spfx-local-workbench.importCsvMock.title": "Import CSV File as Mock",
   "command.spfx-local-workbench.recordRequests.title": "Record Requests and Generate Rules",
+  "command.spfx-local-workbench.showApiProxyLog.title": "Show API Proxy Log",
   "command.spfx-local-workbench.switchToDisplayMode.title": "Switch to Preview Mode",
   "command.spfx-local-workbench.switchToEditMode.title": "Switch to Edit Mode",
   "command.spfx-local-workbench.discardComponents.title": "Discard Components (reset workbench)",
-
-  "submenu.spfx-local-workbench.mockData.label": "Mock Data",
 
   "configuration.spfxLocalWorkbench.group.general.title": "General",
   "configuration.spfxLocalWorkbench.serveUrl.description": "The URL where the SPFx serve is running",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   const log = logger.createChild('Extension');
 
+  // Create a shared output channel for API Proxy logging
+  const apiProxyOutputChannel = vscode.window.createOutputChannel('SPFx API Proxy');
+  context.subscriptions.push(apiProxyOutputChannel);
+
   // Shared detector instance — workspace path rarely changes
   let detector: SpfxProjectDetector | undefined;
   function getDetector(): SpfxProjectDetector | undefined {
@@ -140,7 +144,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.registerWebviewPanelSerializer(
       'spfxLocalWorkbench',
-      new WorkbenchPanelSerializer(context.extensionUri, getDetector),
+      new WorkbenchPanelSerializer(context.extensionUri, getDetector, apiProxyOutputChannel),
     ),
     vscode.window.registerWebviewPanelSerializer(
       'spfxStorybook',
@@ -152,7 +156,7 @@ export function activate(context: vscode.ExtensionContext) {
   const openWorkbenchCommand = vscode.commands.registerCommand(
     'spfx-local-workbench.openWorkbench',
     () => {
-      WorkbenchPanel.createOrShow(context.extensionUri);
+      WorkbenchPanel.createOrShow(context.extensionUri, apiProxyOutputChannel);
     },
   );
 
@@ -162,7 +166,7 @@ export function activate(context: vscode.ExtensionContext) {
     async () => {
       const ready = await startServeIfNeeded();
       if (ready) {
-        WorkbenchPanel.createOrShow(context.extensionUri);
+        WorkbenchPanel.createOrShow(context.extensionUri, apiProxyOutputChannel);
       }
     },
   );
@@ -380,7 +384,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
         return;
       }
-      const proxy = new ApiProxyService(wsFolder.uri.fsPath);
+      const proxy = new ApiProxyService(wsFolder.uri.fsPath, apiProxyOutputChannel);
       await proxy.scaffoldMockConfig();
       proxy.dispose();
       vscode.window.showInformationMessage(
@@ -438,6 +442,14 @@ export function activate(context: vscode.ExtensionContext) {
             'Capture unmatched requests and generate rules',
           ),
           commandId: 'spfx-local-workbench.recordRequests',
+        },
+        {
+          label: `$(output) ${localize('mock.showLog.label', 'Show API Proxy Log')}`,
+          description: localize(
+            'mock.showLog.description',
+            'Open the SPFx API Proxy output channel',
+          ),
+          commandId: 'spfx-local-workbench.showApiProxyLog',
         },
       ];
 
@@ -592,6 +604,14 @@ export function activate(context: vscode.ExtensionContext) {
     },
   );
 
+  // Command to show the SPFx API Proxy output channel
+  const showApiProxyLogCommand = vscode.commands.registerCommand(
+    'spfx-local-workbench.showApiProxyLog',
+    () => {
+      apiProxyOutputChannel.show();
+    },
+  );
+
   // Auto-detect SPFx projects and show status bar items
   const workbenchStatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
@@ -706,6 +726,7 @@ export function activate(context: vscode.ExtensionContext) {
     importJsonCommand,
     importCsvCommand,
     recordRequestsCommand,
+    showApiProxyLogCommand,
     workbenchStatusBarItem,
     storybookStatusBarItem,
   );
@@ -716,6 +737,7 @@ class WorkbenchPanelSerializer implements vscode.WebviewPanelSerializer {
   constructor(
     private readonly _extensionUri: vscode.Uri,
     private readonly _getDetector: () => SpfxProjectDetector | undefined,
+    private readonly _apiProxyOutputChannel: vscode.OutputChannel,
   ) {}
 
   async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, _state: any): Promise<void> {
@@ -726,7 +748,7 @@ class WorkbenchPanelSerializer implements vscode.WebviewPanelSerializer {
 
       if (isSpfx) {
         // Revive the panel
-        WorkbenchPanel.revive(webviewPanel, this._extensionUri);
+        WorkbenchPanel.revive(webviewPanel, this._extensionUri, this._apiProxyOutputChannel);
         return;
       }
     }

--- a/src/loc/extension.nls.fr.json
+++ b/src/loc/extension.nls.fr.json
@@ -37,6 +37,8 @@
   "mock.importCsv.success": "Fichier CSV importé en tant que règle mock.",
   "mock.record.label": "Enregistrer les requêtes",
   "mock.record.description": "Capturer les requêtes non appariées et générer des règles",
+  "mock.showLog.label": "Afficher le journal du proxy API",
+  "mock.showLog.description": "Ouvrir le canal de sortie du proxy API SPFx",
 
   "record.openFirst": "Ouvrez d'abord le workbench, puis démarrez l'enregistrement.",
   "record.noRequests": "Aucune requête non appariée n'a été enregistrée. Toutes les requêtes ont peut-être correspondu à des règles existantes.",

--- a/src/loc/extension.nls.fr.json
+++ b/src/loc/extension.nls.fr.json
@@ -38,7 +38,7 @@
   "mock.record.label": "Enregistrer les requêtes",
   "mock.record.description": "Capturer les requêtes non appariées et générer des règles",
   "mock.showLog.label": "Afficher le journal du proxy API",
-  "mock.showLog.description": "Ouvrir le canal de sortie du proxy API SPFx",
+  "mock.showLog.description": "Ouvrir le canal de sortie « SPFx API Proxy »",
 
   "record.openFirst": "Ouvrez d'abord le workbench, puis démarrez l'enregistrement.",
   "record.noRequests": "Aucune requête non appariée n'a été enregistrée. Toutes les requêtes ont peut-être correspondu à des règles existantes.",

--- a/src/loc/extension.nls.json
+++ b/src/loc/extension.nls.json
@@ -37,6 +37,8 @@
   "mock.importCsv.success": "CSV file imported as mock rule.",
   "mock.record.label": "Record Requests",
   "mock.record.description": "Capture unmatched requests and generate rules",
+  "mock.showLog.label": "Show API Proxy Log",
+  "mock.showLog.description": "Open the SPFx API Proxy output channel",
 
   "record.openFirst": "Open the workbench first, then start recording.",
   "record.noRequests": "No unmatched requests were recorded. All requests may have matched existing rules.",

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -29,6 +29,7 @@ const log = logger.createChild('WorkbenchPanel');
 export class WorkbenchPanel {
   public static currentPanel: WorkbenchPanel | undefined;
   private static readonly viewType = 'spfxLocalWorkbench';
+  private static _apiProxyOutputChannel: vscode.OutputChannel | undefined;
 
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
@@ -84,7 +85,8 @@ export class WorkbenchPanel {
   }
 
   // Creates or reveals the workbench panel
-  public static createOrShow(extensionUri: vscode.Uri): void {
+  public static createOrShow(extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+    WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined;
@@ -126,7 +128,8 @@ export class WorkbenchPanel {
   }
 
   // Revives the panel from a previous session
-  public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri): void {
+  public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+    WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     panel.title = localize('panel.title', 'SPFx Local Workbench');
     WorkbenchPanel.currentPanel = new WorkbenchPanel(panel, extensionUri);
   }
@@ -205,7 +208,10 @@ export class WorkbenchPanel {
     // Initialize the API proxy service
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder) {
-      this._apiProxyService = new ApiProxyService(workspaceFolder.uri.fsPath);
+      this._apiProxyService = new ApiProxyService(
+        workspaceFolder.uri.fsPath,
+        WorkbenchPanel._apiProxyOutputChannel,
+      );
       this._disposables.push(this._apiProxyService);
     }
 

--- a/src/workbench/proxy/ApiProxyService.ts
+++ b/src/workbench/proxy/ApiProxyService.ts
@@ -44,10 +44,17 @@ export class ApiProxyService implements vscode.Disposable {
   private _configWatcher: vscode.FileSystemWatcher | undefined;
   private _recordedRequests: IRecordedRequest[] = [];
 
-  constructor(workspaceRoot: string) {
+  constructor(workspaceRoot: string, outputChannel?: vscode.OutputChannel) {
     this._workspaceRoot = workspaceRoot;
     this._settings = ApiProxyService.readSettings();
-    this._outputChannel = vscode.window.createOutputChannel('SPFx API Proxy');
+
+    // If no output channel provided, create one and add to disposables
+    if (outputChannel) {
+      this._outputChannel = outputChannel;
+    } else {
+      this._outputChannel = vscode.window.createOutputChannel('SPFx API Proxy');
+      this._disposables.push(this._outputChannel);
+    }
 
     // Load initial config
     this._loadConfig();
@@ -384,7 +391,6 @@ export class ApiProxyService implements vscode.Disposable {
   }
 
   dispose(): void {
-    this._outputChannel.dispose();
     for (const d of this._disposables) {
       d.dispose();
     }

--- a/src/workbench/proxy/ApiProxyService.ts
+++ b/src/workbench/proxy/ApiProxyService.ts
@@ -154,7 +154,7 @@ export class ApiProxyService implements vscode.Disposable {
       const rule = this._ruleEngine.match(request);
 
       if (rule) {
-        this._log(`  Matched rule: ${rule.match.url}`);
+        this._log(`  Matched rule: ${rule.name || rule.match.url}`);
         return await this._respondFromRule(request, rule);
       }
 
@@ -351,6 +351,7 @@ export class ApiProxyService implements vscode.Disposable {
       delay: 0,
       rules: [
         {
+          name: 'Get site lists',
           match: {
             url: '/_api/web/lists',
             method: 'GET',

--- a/src/workbench/proxy/generators/CsvFileGenerator.ts
+++ b/src/workbench/proxy/generators/CsvFileGenerator.ts
@@ -116,6 +116,7 @@ export async function importCsvFile(): Promise<IMockRule[] | undefined> {
   }
 
   const rule: IMockRule = {
+    ...(ruleOptions.name ? { name: ruleOptions.name } : {}),
     match: {
       url: ruleOptions.url,
       ...(ruleOptions.method ? { method: ruleOptions.method } : {}),

--- a/src/workbench/proxy/generators/JsonFileGenerator.ts
+++ b/src/workbench/proxy/generators/JsonFileGenerator.ts
@@ -72,6 +72,7 @@ export async function importJsonFile(workspaceRoot: string): Promise<IMockRule[]
   }
 
   const rule: IMockRule = {
+    ...(ruleOptions.name ? { name: ruleOptions.name } : {}),
     match: {
       url: ruleOptions.url,
       ...(ruleOptions.method ? { method: ruleOptions.method } : {}),

--- a/src/workbench/proxy/generators/shared.ts
+++ b/src/workbench/proxy/generators/shared.ts
@@ -90,12 +90,20 @@ export async function promptRuleOptions(titlePrefix: string): Promise<
       method: string | undefined;
       clientType: ApiClientType | undefined;
       status: number;
+      name?: string;
     }
   | undefined
 > {
+  const name = await vscode.window.showInputBox({
+    title: `${titlePrefix} — Rule Name (optional)`,
+    prompt: 'Enter a friendly name for this rule (used in logs and diagnostics)',
+    placeHolder: 'e.g. "Get site lists"',
+    ignoreFocusOut: true,
+  });
+
   const url = await vscode.window.showInputBox({
     title: `${titlePrefix} — URL Pattern`,
-    prompt: 'Enter the URL or URL pattern this rule should match',
+    prompt: 'Enter the URL this rule should match (case-insensitive substring match)',
     placeHolder: '/api/data  or  /_api/web/lists',
     ignoreFocusOut: true,
   });
@@ -148,5 +156,6 @@ export async function promptRuleOptions(titlePrefix: string): Promise<
     method: methodPick.label === 'ANY' ? undefined : methodPick.label,
     clientType: (clientTypePick as { label: string; value: ApiClientType | undefined }).value,
     status: statusPick.status,
+    name: name?.trim() ? name.trim() : undefined,
   };
 }

--- a/src/workbench/proxy/types.ts
+++ b/src/workbench/proxy/types.ts
@@ -36,6 +36,8 @@ export interface IMockRule {
   match: IMockRuleMatch;
   // The response to return when matched
   response: IMockRuleResponse;
+  // Optional friendly name for the rule (used in logs and diagnostics)
+  name?: string;
   // When true, the rule is skipped during matching
   disabled?: boolean;
 }


### PR DESCRIPTION
- Added optional Rule name to make logs easier to read
- Added command to Mock Data menu to show the Output channel since this was pretty tedious (and hidden) otherwise
- Cleaned up some unused submenu definitions (we use a quickpick instead)

---
This pull request introduces support for naming mock API rules, improves the documentation to reflect this new feature, and adds a dedicated "Show API Proxy Log" command and UI entry point. It also standardizes and enhances the documentation tables for clarity, and updates the extension activation logic to properly wire up the new output channel for proxy logs.

**Support for Named Mock Rules:**

* Added support for an optional `name` property on mock rules, allowing each rule to have a friendly identifier. When a rule matches, its name is displayed in logs instead of the URL, making debugging and monitoring easier. Documentation in both `MOCK-DATA.md` and `PROXY.md` was updated with explanations and examples of this feature. [[1]](diffhunk://#diff-322c0b19ce372ca94c22f0d4185e1a3fd9cf123abbe034460141ebca3879a956R29) [[2]](diffhunk://#diff-322c0b19ce372ca94c22f0d4185e1a3fd9cf123abbe034460141ebca3879a956R267-R287) [[3]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eR161-R167) [[4]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eR219-R244)

**API Proxy Log Output Channel and Command:**

* Introduced a shared output channel (`SPFx API Proxy`) for proxy logs, created at extension activation, and passed to relevant services and panels. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R40-R43) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L143-R147) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L155-R159) [[4]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L165-R169) [[5]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L383-R387) [[6]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R740) [[7]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L729-R751)
* Added a new command (`spfx-local-workbench.showApiProxyLog`) and quick-pick menu entry to open the output channel from the UI. Localized strings and command registration were added for this feature. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R607-R614) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R446-R453) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L179-R184) [[4]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5R27-L32) [[5]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0R28-L33)

**Documentation and Table Formatting Improvements:**

* Standardized Markdown tables in `MOCK-DATA.md` and `PROXY.md` for better readability and consistency. [[1]](diffhunk://#diff-322c0b19ce372ca94c22f0d4185e1a3fd9cf123abbe034460141ebca3879a956L305-R328) [[2]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL16-R16) [[3]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL132-R132) [[4]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL143-R143) [[5]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL152-R152) [[6]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL281-R314) [[7]](diffhunk://#diff-98d1f93c6d0d3a8b6923add8148fe5b05cc909fbf286bc59cbf8d2a1e8e4441eL297-R330)

**Other Minor Changes:**

* Removed the now-unused "Mock Data" submenu from the extension manifest and localized resource files. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L235-L256) [[2]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5R27-L32) [[3]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0R28-L33)
* Minor documentation tweaks, such as clarifying CSV import workflows.

These changes collectively make it easier to manage, debug, and monitor mock API rules in the SPFx Local Workbench, while improving the extension's usability and documentation.