### PR TITLE
Settings update

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,21 +243,25 @@
         "title": "%configuration.spfxLocalWorkbench.group.general.title%",
         "properties": {
           "spfxLocalWorkbench.serveUrl": {
+            "order": 10,
             "type": "string",
             "default": "https://localhost:4321",
             "description": "%configuration.spfxLocalWorkbench.serveUrl.description%"
           },
           "spfxLocalWorkbench.autoOpenWorkbench": {
+            "order": 20,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.autoOpenWorkbench.description%"
           },
           "spfxLocalWorkbench.serveCommand": {
+            "order": 30,
             "type": "string",
             "default": "heft start --clean --nobrowser",
             "markdownDescription": "%configuration.spfxLocalWorkbench.serveCommand.mdDescription%"
           },
           "spfxLocalWorkbench.statusBarWorkbenchAction": {
+            "order": 40,
             "type": "string",
             "enum": [
               "openWorkbench",
@@ -271,6 +275,7 @@
             "description": "%configuration.spfxLocalWorkbench.statusBarWorkbenchAction.description%"
           },
           "spfxLocalWorkbench.statusBarStorybookAction": {
+            "order": 50,
             "type": "string",
             "enum": [
               "openStorybook",
@@ -284,6 +289,7 @@
             "description": "%configuration.spfxLocalWorkbench.statusBarStorybookAction.description%"
           },
           "spfxLocalWorkbench.statusBarDisplay": {
+            "order": 60,
             "type": "string",
             "enum": [
               "iconAndText",
@@ -304,6 +310,7 @@
         "title": "%configuration.spfxLocalWorkbench.group.theme.title%",
         "properties": {
           "spfxLocalWorkbench.theme.current": {
+            "order": 10,
             "type": "string",
             "enum": [
               "Teal",
@@ -335,11 +342,13 @@
             "description": "%configuration.spfxLocalWorkbench.theme.current.description%"
           },
           "spfxLocalWorkbench.theme.customName": {
+            "order": 20,
             "type": "string",
             "default": "",
             "markdownDescription": "%configuration.spfxLocalWorkbench.theme.customName.mdDescription%"
           },
           "spfxLocalWorkbench.theme.custom": {
+            "order": 30,
             "type": "array",
             "default": [],
             "markdownDescription": "%configuration.spfxLocalWorkbench.theme.custom.mdDescription%",
@@ -509,6 +518,7 @@
         "title": "%configuration.spfxLocalWorkbench.group.context.title%",
         "properties": {
           "spfxLocalWorkbench.context.pageContext": {
+            "order": 10,
             "type": "object",
             "default": {
               "site": {
@@ -621,36 +631,43 @@
         "title": "%configuration.spfxLocalWorkbench.group.storybook.title%",
         "properties": {
           "spfxLocalWorkbench.storybook.port": {
+            "order": 10,
             "type": "number",
             "default": 6006,
             "description": "%configuration.spfxLocalWorkbench.storybook.port.description%"
           },
           "spfxLocalWorkbench.storybook.autoGenerate": {
+            "order": 20,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.storybook.autoGenerate.description%"
           },
           "spfxLocalWorkbench.storybook.storiesPattern": {
+            "order": 30,
             "type": "string",
             "default": "src/**/*.stories.ts",
             "description": "%configuration.spfxLocalWorkbench.storybook.storiesPattern.description%"
           },
           "spfxLocalWorkbench.storybook.generateLocaleStories": {
+            "order": 40,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description%"
           },
           "spfxLocalWorkbench.storybook.autoDocs": {
+            "order": 50,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.storybook.autoDocs.description%"
           },
           "spfxLocalWorkbench.storybook.skipInstallPrompt": {
+            "order": 60,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description%"
           },
           "spfxLocalWorkbench.storybook.theme": {
+            "order": 70,
             "type": "string",
             "default": "matchVsCode",
             "enum": [
@@ -673,11 +690,13 @@
         "title": "%configuration.spfxLocalWorkbench.group.proxy.title%",
         "properties": {
           "spfxLocalWorkbench.proxy.enabled": {
+            "order": 10,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.enabled.description%"
           },
           "spfxLocalWorkbench.proxy.mode": {
+            "order": 20,
             "type": "string",
             "default": "mock",
             "enum": [
@@ -695,26 +714,31 @@
             "description": "%configuration.spfxLocalWorkbench.proxy.mode.description%"
           },
           "spfxLocalWorkbench.proxy.mockFile": {
+            "order": 30,
             "type": "string",
             "default": ".spfx-workbench/api-mocks.json",
             "description": "%configuration.spfxLocalWorkbench.proxy.mockFile.description%"
           },
           "spfxLocalWorkbench.proxy.defaultDelay": {
+            "order": 40,
             "type": "number",
             "default": 0,
             "description": "%configuration.spfxLocalWorkbench.proxy.defaultDelay.description%"
           },
           "spfxLocalWorkbench.proxy.fallbackStatus": {
+            "order": 50,
             "type": "number",
             "default": 404,
             "description": "%configuration.spfxLocalWorkbench.proxy.fallbackStatus.description%"
           },
           "spfxLocalWorkbench.proxy.logRequests": {
+            "order": 60,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.logRequests.description%"
           },
           "spfxLocalWorkbench.proxy.allowedOrigins": {
+            "order": 70,
             "type": "array",
             "items": {
               "type": "string"
@@ -723,6 +747,7 @@
             "description": "%configuration.spfxLocalWorkbench.proxy.allowedOrigins.description%"
           },
           "spfxLocalWorkbench.proxy.serveMocksWhileRecording": {
+            "order": 80,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description%"

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -117,7 +117,7 @@
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port du serveur de développement Storybook",
   "configuration.spfxLocalWorkbench.storybook.autoGenerate.description": "Générer automatiquement les histoires à partir des manifestes de composants SPFx",
-  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Motif glob pour découvrir les fichiers d'histoires personnalisées dans le projet SPFx",
+  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Motif glob pour découvrir les fichiers d'histoires personnalisées dans le projet SPFx (relatif à la racine de l'espace de travail, par ex. `src/**/*.stories.{ts,tsx}`)",
   "configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description": "Générer automatiquement des variantes d'histoires pour chaque locale prise en charge",
   "configuration.spfxLocalWorkbench.storybook.autoDocs.description": "Activer les pages de documentation générées automatiquement pour les histoires dans Storybook",
   "configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description": "Installer automatiquement les dépendances Storybook sans demander",

--- a/package.nls.json
+++ b/package.nls.json
@@ -118,7 +118,7 @@
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port for the Storybook dev server",
   "configuration.spfxLocalWorkbench.storybook.autoGenerate.description": "Automatically generate stories from SPFx component manifests",
-  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Glob pattern for discovering custom story files in the SPFx project",
+  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Glob pattern for discovering custom story files in the SPFx project (relative to workspace root, e.g. `src/**/*.stories.{ts,tsx}`)",
   "configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description": "Automatically generate story variants for each supported locale",
   "configuration.spfxLocalWorkbench.storybook.autoDocs.description": "Enable auto-generated documentation pages for stories in Storybook",
   "configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description": "Automatically install Storybook dependencies without prompting",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,7 @@ export function activate(context: vscode.ExtensionContext) {
     () => {
       vscode.commands.executeCommand(
         'workbench.action.openWorkspaceSettings',
-        '@ext:BeauCameron.spfx-local-workbench',
+        '@ext:thechriskent.spfx-local-workbench',
       );
     },
   );

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -279,6 +279,17 @@ export class WorkbenchPanel {
         vscode.commands.executeCommand('workbench.action.webview.openDeveloperTools');
         return;
 
+      case 'openSettings':
+        vscode.commands.executeCommand(
+          'workbench.action.openSettings',
+          '@ext:thechriskent.spfx-local-workbench',
+        );
+        return;
+
+      case 'startServe':
+        vscode.commands.executeCommand('spfx-local-workbench.startServeWorkbench');
+        return;
+
       case 'mockDataMenu':
         vscode.commands.executeCommand('spfx-local-workbench.mockDataMenu');
         return;
@@ -406,6 +417,7 @@ export class WorkbenchPanel {
     return generateWorkbenchHtml({
       nonce,
       serveUrl: this._settings.serveUrl,
+      serveCommand: this._settings.serveCommand,
       webPartsJson,
       extensionsJson,
       cspSource: webview.cspSource,

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -5,7 +5,7 @@
 // extension and the webview.
 import * as vscode from 'vscode';
 
-import { LIVE_RELOAD_DEBOUNCE_MS, DisplayMode } from '@spfx-local-workbench/shared';
+import { DisplayMode, LIVE_RELOAD_DEBOUNCE_MS } from '@spfx-local-workbench/shared';
 import type { IExtensionManifest, IWebPartManifest } from '@spfx-local-workbench/shared';
 import { logger } from '@spfx-local-workbench/shared';
 import { getNonce, localize } from '@spfx-local-workbench/shared/utils/node';
@@ -85,7 +85,10 @@ export class WorkbenchPanel {
   }
 
   // Creates or reveals the workbench panel
-  public static createOrShow(extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    apiProxyOutputChannel?: vscode.OutputChannel,
+  ): void {
     WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
@@ -128,7 +131,11 @@ export class WorkbenchPanel {
   }
 
   // Revives the panel from a previous session
-  public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+  public static revive(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    apiProxyOutputChannel?: vscode.OutputChannel,
+  ): void {
     WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     panel.title = localize('panel.title', 'SPFx Local Workbench');
     WorkbenchPanel.currentPanel = new WorkbenchPanel(panel, extensionUri);
@@ -280,10 +287,7 @@ export class WorkbenchPanel {
         return;
 
       case 'openSettings':
-        vscode.commands.executeCommand(
-          'workbench.action.openSettings',
-          '@ext:thechriskent.spfx-local-workbench',
-        );
+        vscode.commands.executeCommand('spfx-local-workbench.openSettings');
         return;
 
       case 'startServe':

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -12,6 +12,7 @@ import type { IContextConfig } from '../config/WorkbenchConfig';
 export interface IHtmlGeneratorConfig {
   nonce: string;
   serveUrl: string;
+  serveCommand: string;
   webPartsJson: string;
   extensionsJson?: string;
   cspSource: string;
@@ -116,6 +117,7 @@ function generateScripts(config: IHtmlGeneratorConfig): string {
   // Prepare configuration object to inject
   const workbenchConfig = {
     serveUrl: config.serveUrl,
+    serveCommand: config.serveCommand,
     webParts: webParts,
     extensions: extensions,
     theme: config.currentTheme,

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -93,7 +93,7 @@ function generateStatusBar(
     <div class="status-bar">
         <div class="status-indicator">
             <div class="status-dot" id="status-dot"></div>
-            <span id="status-text">Initializing...</span>
+            <div id="status-text">Initializing...</div>
         </div>
         <span id="component-count">${countText}</span>
         <div class="separator"></div>

--- a/src/workbench/types/IWebviewMessage.ts
+++ b/src/workbench/types/IWebviewMessage.ts
@@ -6,6 +6,8 @@ export interface IWebviewMessage {
     | 'refresh'
     | 'setServeUrl'
     | 'openDevTools'
+    | 'openSettings'
+    | 'startServe'
     | 'log'
     | 'error'
     | 'vscodeThemeColors'

--- a/webview/src/WorkbenchRuntime.ts
+++ b/webview/src/WorkbenchRuntime.ts
@@ -598,6 +598,14 @@ export class WorkbenchRuntime {
     this.vscode.postMessage({ command: 'mockDataMenu' });
   }
 
+  handleStartServe(): void {
+    this.vscode.postMessage({ command: 'startServe' });
+  }
+
+  handleOpenSettings(): void {
+    this.vscode.postMessage({ command: 'openSettings' });
+  }
+
   private updateStatus(message: string): void {
     const loadingStatus = document.getElementById('loading-status');
     const statusText = document.getElementById('status-text');

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
@@ -1,17 +1,5 @@
 /* WorkbenchCanvas component styles */
 
-:global {
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-
-    to {
-      transform: rotate(360deg);
-    }
-  }
-}
-
 .canvas {
   max-width: 1028px;
   margin: 0 auto;

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
@@ -1,5 +1,17 @@
 /* WorkbenchCanvas component styles */
 
+:global {
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}
+
 .canvas {
   max-width: 1028px;
   margin: 0 auto;

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
@@ -72,7 +72,10 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
           tokens={{ childrenGap: 16 }}
           styles={{ root: { padding: '24px' } }}
         >
-          <Text variant="large" styles={{ root: { color: '#a80000', marginBottom: 16 } }}>
+          <Text
+            variant="large"
+            styles={{ root: { color: '#a80000', marginBottom: 16, textAlign: 'center' } }}
+          >
             No SPFx components found. Make sure your project is served / running.
           </Text>
           <PrimaryButton

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Stack, Text } from '@fluentui/react';
+import { IconButton, Link, PrimaryButton, Stack, Text } from '@fluentui/react';
 import React, { FC, Fragment, useMemo, useState } from 'react';
 
 import type {
@@ -34,6 +34,7 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
   locale,
 }) => {
   const [openPickerIndex, setOpenPickerIndex] = useState<number | null>(null);
+  const [serveClicked, setServeClicked] = useState(false);
 
   const handleAddClick = (insertIndex: number) => {
     setOpenPickerIndex(openPickerIndex === insertIndex ? null : insertIndex);
@@ -52,13 +53,58 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
     setOpenPickerIndex(null);
   };
 
+  const handleStartServe = () => {
+    setServeClicked(true);
+    window.dispatchEvent(new CustomEvent('startServe'));
+  };
+
+  const handleOpenSettings = () => {
+    window.dispatchEvent(new CustomEvent('openSettings'));
+  };
+
   if (manifests.length === 0) {
+    const serveCommand = window.__workbenchConfig?.serveCommand || 'heft start --clean --nobrowser';
+
     return (
       <div id="canvas">
-        <Stack horizontalAlign="center" styles={{ root: { padding: '24px' } }}>
-          <Text variant="large" styles={{ root: { color: '#a80000' } }}>
+        <Stack
+          horizontalAlign="center"
+          tokens={{ childrenGap: 16 }}
+          styles={{ root: { padding: '24px' } }}
+        >
+          <Text variant="large" styles={{ root: { color: '#a80000', marginBottom: 16 } }}>
             No SPFx components found. Make sure your project is served / running.
           </Text>
+          <PrimaryButton
+            text="Serve"
+            onClick={handleStartServe}
+            disabled={serveClicked}
+            iconProps={serveClicked ? { iconName: 'Sync' } : undefined}
+            styles={
+              serveClicked
+                ? {
+                    icon: {
+                      animation: 'spin 1.5s linear infinite',
+                    },
+                  }
+                : undefined
+            }
+          />
+          <Stack
+            horizontal
+            tokens={{ childrenGap: 4 }}
+            styles={{ root: { alignItems: 'flex-end' } }}
+          >
+            <Text variant="small" styles={{ root: { color: '#605e5c', marginRight: 4 } }}>
+              Command:
+            </Text>
+            <Text variant="small" styles={{ root: { fontFamily: 'monospace', color: '#323130' } }}>
+              {serveCommand}
+            </Text>
+          </Stack>
+          <Link onClick={handleOpenSettings} styles={{ root: { fontSize: 12 } }}>
+            Open Extension Settings
+          </Link>
         </Stack>
       </div>
     );

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -95,6 +95,14 @@ function initialize() {
       runtime.handleMockData();
     }) as EventListener);
 
+    window.addEventListener('startServe', (() => {
+      runtime.handleStartServe();
+    }) as EventListener);
+
+    window.addEventListener('openSettings', (() => {
+      runtime.handleOpenSettings();
+    }) as EventListener);
+
     // Listen for live reload messages from the extension
     window.addEventListener('message', (event: MessageEvent) => {
       const message = event.data;

--- a/webview/src/styles/global.css
+++ b/webview/src/styles/global.css
@@ -16,6 +16,7 @@ body {
   background-color: var(--primaryBackground, white);
   height: auto;
   min-height: 100vh;
+  min-width: 364px;
   overflow-y: auto;
 }
 
@@ -65,6 +66,7 @@ body {
   font-size: 12px;
   color: var(--neutralSecondary, #605e5c);
   z-index: 100;
+  white-space: nowrap;
 }
 
 .status-bar .separator {
@@ -79,10 +81,12 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .status-dot {
   width: 8px;
+  min-width: 8px;
   height: 8px;
   border-radius: 50%;
   background: #107c10;
@@ -90,4 +94,17 @@ body {
 
 .status-dot.disconnected {
   background: #d13438;
+}
+
+#status-text,
+#component-count {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 500px) {
+  .status-bar {
+    padding: 6px;
+  }
 }

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -16,6 +16,7 @@ export interface IVsCodeApi {
 
 export interface IWorkbenchConfig {
   serveUrl: string;
+  serveCommand: string;
   webParts: IWebPartManifest[];
   extensions?: IExtensionManifest[];
   /** The active SharePoint theme. Comes from `spfxLocalWorkbench.theme.current` (+ custom). */


### PR DESCRIPTION
- Fixes the settings button
- Adds a serve button when serve isn't running:

<img width="514" height="268" alt="image" src="https://github.com/user-attachments/assets/50438de5-de3f-431b-ac38-1f5f1b4e2f75" />

---

This pull request focuses on improving the user experience and configuration for the SPFx Local Workbench extension. The main changes include adding explicit ordering to configuration properties, enhancing the empty state UI with actionable buttons, and improving communication between the webview and the extension host. Additionally, there are minor style and localization updates.

**Configuration Improvements**

* Added `order` fields to all configuration properties in `package.json` to control their display order in the settings UI, making the configuration experience more organized and user-friendly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R246-R264) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R278) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R292) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R313) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R345-R351) [[6]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R521) [[7]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R634-R670) [[8]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R693-R699) [[9]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R717-R741) [[10]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R750)
* Updated the description for the `storybook.storiesPattern` configuration property in both English and French localization files to clarify that the pattern is relative to the workspace root and provide an example. [[1]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L121-R121) [[2]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L120-R120)

**Webview and UI Enhancements**

* Improved the empty state UI in `WorkbenchCanvas` to include a prominent "Serve" button (which triggers the serve command), display the actual serve command, and provide a link to open extension settings directly from the UI. [[1]](diffhunk://#diff-97f55ba5096714a037888b8a8f78c448cba433554128ffef964b3c48c66a0777R37) [[2]](diffhunk://#diff-97f55ba5096714a037888b8a8f78c448cba433554128ffef964b3c48c66a0777R56-R110)
* Added new webview-to-extension message types (`openSettings`, `startServe`) and corresponding handlers in both the extension backend and webview runtime, enabling the new UI actions to trigger the appropriate VS Code commands. [[1]](diffhunk://#diff-9c2bcf581353fc6d62d28e7a1bf52f7623d37d501947f2f326aafa67c81d5480R9-R10) [[2]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fR282-R292) [[3]](diffhunk://#diff-c54b372e82f4055a41055a648809a3cab119f92b52ae275b48701de6d125edf7R601-R608) [[4]](diffhunk://#diff-deb93b6d7be35f3b811970b74d8f25bebf87b7851d1df38d78a52ad4fe5305f7R98-R105)
* Passed the `serveCommand` configuration value from the extension host to the webview, so the UI can display the actual command users should run. [[1]](diffhunk://#diff-3a87b520b8316564e87e9214d8a8da816c5a15f699a1f6d5b090c233a3642113R15) [[2]](diffhunk://#diff-3a87b520b8316564e87e9214d8a8da816c5a15f699a1f6d5b090c233a3642113R120) F4061d21L406R417)

**Styling Updates**

* Added a spinning animation for the "Serve" button icon to indicate activity, and made various small CSS tweaks to improve layout and responsiveness in the webview. [[1]](diffhunk://#diff-bc8931de41b7450b6fc427a3866b2a48895c21e4c8cfd0f0df13f8de4b37818eR3-R14) [[2]](diffhunk://#diff-113f2c76361425fac5b1a79a1365b3ad72c1a9ecb2af7773b25d66fbb6ef0573R19) [[3]](diffhunk://#diff-113f2c76361425fac5b1a79a1365b3ad72c1a9ecb2af7773b25d66fbb6ef0573R69) [[4]](diffhunk://#diff-113f2c76361425fac5b1a79a1365b3ad72c1a9ecb2af7773b25d66fbb6ef0573R84-R89)

**Other Fixes**

* Updated the extension ID in a command to reflect the new publisher.

These changes collectively make the extension easier to configure, more intuitive to use (especially for first-time users), and visually more polished.