### PR TITLE
Property pane updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,16 @@ node -e "import('@spfx-local-workbench/shared').then(m => console.log(Object.key
 1. **Storybook UI**: Match Storybook's design system and practices
 2. **SPFx surfaces**: Use Fluent UI styles, must be themeable
 3. **VS Code UI**: Match VS Code conventions for commands, panels, etc.
+4. **Combining CSS module classes**: Always use the Fluent UI `css()` utility (from `@fluentui/react`) when combining CSS module class names in components where Fluent is already available — it handles falsy/undefined values cleanly:
+
+   ```tsx
+   // ✅ Correct
+   import { css } from '@fluentui/react';
+   <div className={css(styles.root, isOpen && styles.open)} />
+
+   // ❌ Avoid
+   <div className={`${styles.root}${isOpen ? ` ${styles.open}` : ''}`} />
+   ```
 
 ### Build Requirements
 

--- a/package.json
+++ b/package.json
@@ -243,21 +243,25 @@
         "title": "%configuration.spfxLocalWorkbench.group.general.title%",
         "properties": {
           "spfxLocalWorkbench.serveUrl": {
+            "order": 10,
             "type": "string",
             "default": "https://localhost:4321",
             "description": "%configuration.spfxLocalWorkbench.serveUrl.description%"
           },
           "spfxLocalWorkbench.autoOpenWorkbench": {
+            "order": 20,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.autoOpenWorkbench.description%"
           },
           "spfxLocalWorkbench.serveCommand": {
+            "order": 30,
             "type": "string",
             "default": "heft start --clean --nobrowser",
             "markdownDescription": "%configuration.spfxLocalWorkbench.serveCommand.mdDescription%"
           },
           "spfxLocalWorkbench.statusBarWorkbenchAction": {
+            "order": 40,
             "type": "string",
             "enum": [
               "openWorkbench",
@@ -271,6 +275,7 @@
             "description": "%configuration.spfxLocalWorkbench.statusBarWorkbenchAction.description%"
           },
           "spfxLocalWorkbench.statusBarStorybookAction": {
+            "order": 50,
             "type": "string",
             "enum": [
               "openStorybook",
@@ -284,6 +289,7 @@
             "description": "%configuration.spfxLocalWorkbench.statusBarStorybookAction.description%"
           },
           "spfxLocalWorkbench.statusBarDisplay": {
+            "order": 60,
             "type": "string",
             "enum": [
               "iconAndText",
@@ -304,6 +310,7 @@
         "title": "%configuration.spfxLocalWorkbench.group.theme.title%",
         "properties": {
           "spfxLocalWorkbench.theme.current": {
+            "order": 10,
             "type": "string",
             "enum": [
               "Teal",
@@ -335,11 +342,13 @@
             "description": "%configuration.spfxLocalWorkbench.theme.current.description%"
           },
           "spfxLocalWorkbench.theme.customName": {
+            "order": 20,
             "type": "string",
             "default": "",
             "markdownDescription": "%configuration.spfxLocalWorkbench.theme.customName.mdDescription%"
           },
           "spfxLocalWorkbench.theme.custom": {
+            "order": 30,
             "type": "array",
             "default": [],
             "markdownDescription": "%configuration.spfxLocalWorkbench.theme.custom.mdDescription%",
@@ -509,6 +518,7 @@
         "title": "%configuration.spfxLocalWorkbench.group.context.title%",
         "properties": {
           "spfxLocalWorkbench.context.pageContext": {
+            "order": 10,
             "type": "object",
             "default": {
               "site": {
@@ -621,36 +631,43 @@
         "title": "%configuration.spfxLocalWorkbench.group.storybook.title%",
         "properties": {
           "spfxLocalWorkbench.storybook.port": {
+            "order": 10,
             "type": "number",
             "default": 6006,
             "description": "%configuration.spfxLocalWorkbench.storybook.port.description%"
           },
           "spfxLocalWorkbench.storybook.autoGenerate": {
+            "order": 20,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.storybook.autoGenerate.description%"
           },
           "spfxLocalWorkbench.storybook.storiesPattern": {
+            "order": 30,
             "type": "string",
             "default": "src/**/*.stories.ts",
             "description": "%configuration.spfxLocalWorkbench.storybook.storiesPattern.description%"
           },
           "spfxLocalWorkbench.storybook.generateLocaleStories": {
+            "order": 40,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description%"
           },
           "spfxLocalWorkbench.storybook.autoDocs": {
+            "order": 50,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.storybook.autoDocs.description%"
           },
           "spfxLocalWorkbench.storybook.skipInstallPrompt": {
+            "order": 60,
             "type": "boolean",
             "default": false,
             "description": "%configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description%"
           },
           "spfxLocalWorkbench.storybook.theme": {
+            "order": 70,
             "type": "string",
             "default": "matchVsCode",
             "enum": [
@@ -673,11 +690,13 @@
         "title": "%configuration.spfxLocalWorkbench.group.proxy.title%",
         "properties": {
           "spfxLocalWorkbench.proxy.enabled": {
+            "order": 10,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.enabled.description%"
           },
           "spfxLocalWorkbench.proxy.mode": {
+            "order": 20,
             "type": "string",
             "default": "mock",
             "enum": [
@@ -695,26 +714,31 @@
             "description": "%configuration.spfxLocalWorkbench.proxy.mode.description%"
           },
           "spfxLocalWorkbench.proxy.mockFile": {
+            "order": 30,
             "type": "string",
             "default": ".spfx-workbench/api-mocks.json",
             "description": "%configuration.spfxLocalWorkbench.proxy.mockFile.description%"
           },
           "spfxLocalWorkbench.proxy.defaultDelay": {
+            "order": 40,
             "type": "number",
             "default": 0,
             "description": "%configuration.spfxLocalWorkbench.proxy.defaultDelay.description%"
           },
           "spfxLocalWorkbench.proxy.fallbackStatus": {
+            "order": 50,
             "type": "number",
             "default": 404,
             "description": "%configuration.spfxLocalWorkbench.proxy.fallbackStatus.description%"
           },
           "spfxLocalWorkbench.proxy.logRequests": {
+            "order": 60,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.logRequests.description%"
           },
           "spfxLocalWorkbench.proxy.allowedOrigins": {
+            "order": 70,
             "type": "array",
             "items": {
               "type": "string"
@@ -723,6 +747,7 @@
             "description": "%configuration.spfxLocalWorkbench.proxy.allowedOrigins.description%"
           },
           "spfxLocalWorkbench.proxy.serveMocksWhileRecording": {
+            "order": 80,
             "type": "boolean",
             "default": true,
             "description": "%configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description%"

--- a/package.json
+++ b/package.json
@@ -687,6 +687,17 @@
         }
       },
       {
+        "title": "%configuration.spfxLocalWorkbench.group.workbench.title%",
+        "properties": {
+          "spfxLocalWorkbench.propertyPane.shrinkCanvas": {
+            "order": 10,
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.spfxLocalWorkbench.propertyPane.shrinkCanvas.description%"
+          }
+        }
+      },
+      {
         "title": "%configuration.spfxLocalWorkbench.group.proxy.title%",
         "properties": {
           "spfxLocalWorkbench.proxy.enabled": {

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -117,7 +117,7 @@
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port du serveur de développement Storybook",
   "configuration.spfxLocalWorkbench.storybook.autoGenerate.description": "Générer automatiquement les histoires à partir des manifestes de composants SPFx",
-  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Motif glob pour découvrir les fichiers d'histoires personnalisées dans le projet SPFx",
+  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Motif glob pour découvrir les fichiers d'histoires personnalisées dans le projet SPFx (relatif à la racine de l'espace de travail, par ex. `src/**/*.stories.{ts,tsx}`)",
   "configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description": "Générer automatiquement des variantes d'histoires pour chaque locale prise en charge",
   "configuration.spfxLocalWorkbench.storybook.autoDocs.description": "Activer les pages de documentation générées automatiquement pour les histoires dans Storybook",
   "configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description": "Installer automatiquement les dépendances Storybook sans demander",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -139,5 +139,7 @@
   "configuration.spfxLocalWorkbench.proxy.fallbackStatus.description": "Code d'état HTTP retourné lorsqu'aucune règle mock ne correspond en mode mock",
   "configuration.spfxLocalWorkbench.proxy.logRequests.description": "Enregistrer toutes les requêtes proxy dans le canal de sortie 'SPFx API Proxy'",
   "configuration.spfxLocalWorkbench.proxy.allowedOrigins.description": "Modèles d'URL autorisés en mode passthrough (vide = tous)",
-  "configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description": "En mode enregistrement, servir également les règles mock existantes pour les requêtes appariées"
+  "configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description": "En mode enregistrement, servir également les règles mock existantes pour les requêtes appariées",
+  "configuration.spfxLocalWorkbench.group.workbench.title": "Workbench",
+  "configuration.spfxLocalWorkbench.propertyPane.shrinkCanvas.description": "Lorsque le volet des propriétés est ouvert, réduire la largeur du canvas (correspond au workbench en ligne) ; désactiver pour superposer le volet des propriétés à la place."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -140,5 +140,7 @@
   "configuration.spfxLocalWorkbench.proxy.fallbackStatus.description": "HTTP status code returned when no Mock rule matches in mock mode",
   "configuration.spfxLocalWorkbench.proxy.logRequests.description": "Log all proxied API requests to the 'SPFx API Proxy' output channel",
   "configuration.spfxLocalWorkbench.proxy.allowedOrigins.description": "URL patterns allowed in passthrough mode (empty = all)",
-  "configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description": "When in record mode, also serve existing mock rules for matched requests"
+  "configuration.spfxLocalWorkbench.proxy.serveMocksWhileRecording.description": "When in record mode, also serve existing mock rules for matched requests",
+  "configuration.spfxLocalWorkbench.group.workbench.title": "Workbench",
+  "configuration.spfxLocalWorkbench.propertyPane.shrinkCanvas.description": "When the property pane is open, shrink the canvas width (matches online workbench), disable to instead overlay the property pane."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -118,7 +118,7 @@
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port for the Storybook dev server",
   "configuration.spfxLocalWorkbench.storybook.autoGenerate.description": "Automatically generate stories from SPFx component manifests",
-  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Glob pattern for discovering custom story files in the SPFx project",
+  "configuration.spfxLocalWorkbench.storybook.storiesPattern.description": "Glob pattern for discovering custom story files in the SPFx project (relative to workspace root, e.g. `src/**/*.stories.{ts,tsx}`)",
   "configuration.spfxLocalWorkbench.storybook.generateLocaleStories.description": "Automatically generate story variants for each supported locale",
   "configuration.spfxLocalWorkbench.storybook.autoDocs.description": "Enable auto-generated documentation pages for stories in Storybook",
   "configuration.spfxLocalWorkbench.storybook.skipInstallPrompt.description": "Automatically install Storybook dependencies without prompting",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,7 @@ export function activate(context: vscode.ExtensionContext) {
     () => {
       vscode.commands.executeCommand(
         'workbench.action.openWorkspaceSettings',
-        '@ext:BeauCameron.spfx-local-workbench',
+        '@ext:thechriskent.spfx-local-workbench',
       );
     },
   );

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -279,6 +279,17 @@ export class WorkbenchPanel {
         vscode.commands.executeCommand('workbench.action.webview.openDeveloperTools');
         return;
 
+      case 'openSettings':
+        vscode.commands.executeCommand(
+          'workbench.action.openSettings',
+          '@ext:thechriskent.spfx-local-workbench',
+        );
+        return;
+
+      case 'startServe':
+        vscode.commands.executeCommand('spfx-local-workbench.startServeWorkbench');
+        return;
+
       case 'mockDataMenu':
         vscode.commands.executeCommand('spfx-local-workbench.mockDataMenu');
         return;
@@ -406,6 +417,7 @@ export class WorkbenchPanel {
     return generateWorkbenchHtml({
       nonce,
       serveUrl: this._settings.serveUrl,
+      serveCommand: this._settings.serveCommand,
       webPartsJson,
       extensionsJson,
       cspSource: webview.cspSource,

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -5,7 +5,7 @@
 // extension and the webview.
 import * as vscode from 'vscode';
 
-import { LIVE_RELOAD_DEBOUNCE_MS, DisplayMode } from '@spfx-local-workbench/shared';
+import { DisplayMode, LIVE_RELOAD_DEBOUNCE_MS } from '@spfx-local-workbench/shared';
 import type { IExtensionManifest, IWebPartManifest } from '@spfx-local-workbench/shared';
 import { logger } from '@spfx-local-workbench/shared';
 import { getNonce, localize } from '@spfx-local-workbench/shared/utils/node';
@@ -85,7 +85,10 @@ export class WorkbenchPanel {
   }
 
   // Creates or reveals the workbench panel
-  public static createOrShow(extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    apiProxyOutputChannel?: vscode.OutputChannel,
+  ): void {
     WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
@@ -128,7 +131,11 @@ export class WorkbenchPanel {
   }
 
   // Revives the panel from a previous session
-  public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, apiProxyOutputChannel?: vscode.OutputChannel): void {
+  public static revive(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    apiProxyOutputChannel?: vscode.OutputChannel,
+  ): void {
     WorkbenchPanel._apiProxyOutputChannel = apiProxyOutputChannel;
     panel.title = localize('panel.title', 'SPFx Local Workbench');
     WorkbenchPanel.currentPanel = new WorkbenchPanel(panel, extensionUri);
@@ -280,10 +287,7 @@ export class WorkbenchPanel {
         return;
 
       case 'openSettings':
-        vscode.commands.executeCommand(
-          'workbench.action.openSettings',
-          '@ext:thechriskent.spfx-local-workbench',
-        );
+        vscode.commands.executeCommand('spfx-local-workbench.openSettings');
         return;
 
       case 'startServe':

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -430,6 +430,7 @@ export class WorkbenchPanel {
       customThemes: getCustomThemes(),
       contextSettings: this._settings.context,
       proxyEnabled: this._apiProxyService?.enabled ?? true,
+      propertyPaneShrinkCanvas: this._settings.propertyPaneShrinkCanvas,
       externalDependencies: this._externalDependencies,
     });
   }

--- a/src/workbench/config/WorkbenchConfig.ts
+++ b/src/workbench/config/WorkbenchConfig.ts
@@ -25,7 +25,6 @@ export interface IWorkbenchSettings {
   autoOpenWorkbench: boolean;
   serveCommand: string;
   context: IContextConfig;
-  /** Whether opening the property pane shrinks the canvas width to make room (default true). */
   propertyPaneShrinkCanvas: boolean;
 }
 

--- a/src/workbench/config/WorkbenchConfig.ts
+++ b/src/workbench/config/WorkbenchConfig.ts
@@ -25,6 +25,8 @@ export interface IWorkbenchSettings {
   autoOpenWorkbench: boolean;
   serveCommand: string;
   context: IContextConfig;
+  /** Whether opening the property pane shrinks the canvas width to make room (default true). */
+  propertyPaneShrinkCanvas: boolean;
 }
 
 // Default configuration values
@@ -35,6 +37,7 @@ const defaults = {
   context: {
     pageContext: DEFAULT_PAGE_CONTEXT,
   },
+  propertyPaneShrinkCanvas: true,
 };
 
 // Gets the current workbench configuration from VS Code settings
@@ -54,6 +57,10 @@ export function getWorkbenchSettings(): IWorkbenchSettings {
     context: {
       pageContext,
     },
+    propertyPaneShrinkCanvas: config.get<boolean>(
+      'propertyPane.shrinkCanvas',
+      defaults.propertyPaneShrinkCanvas,
+    ),
   };
 }
 

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -105,6 +105,33 @@ function generateStatusBar(
     `;
 }
 
+/**
+ * Escapes a string for safe embedding as HTML text content.
+ * Prevents an untrusted message from injecting tags or entities into the page.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Serializes a value to JSON that is safe to embed directly in an HTML `<script>` tag.
+ * `JSON.stringify` does not escape `<`, `>`, or `&`, so a string like `</script>`
+ * inside a config value would prematurely close the script tag. Replacing those
+ * characters with their Unicode escape sequences produces valid JSON that the HTML
+ * parser cannot misinterpret.
+ */
+function safeJsonStringify(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
 // Generates the scripts section HTML
 function generateScripts(config: IHtmlGeneratorConfig): string {
   // Get URI for the bundled webview script
@@ -179,7 +206,7 @@ ${externalScripts ? `    <!-- SPFx project externals (loaded from project node_m
     
     <!-- Inject workbench configuration -->
     <script nonce="${config.nonce}">
-        window.__workbenchConfig = ${JSON.stringify(workbenchConfig)};
+        window.__workbenchConfig = ${safeJsonStringify(workbenchConfig)};
     </script>
     
     <!-- Bundled workbench runtime -->
@@ -242,7 +269,7 @@ export function generateErrorHtml(errorMessage: string): string {
 <body>
     <div class="error-box">
         <h2>⚠️ Workbench Error</h2>
-        <p>${errorMessage}</p>
+        <p>${escapeHtml(errorMessage)}</p>
     </div>
 </body>
 </html>`;

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -12,6 +12,7 @@ import type { IContextConfig } from '../config/WorkbenchConfig';
 export interface IHtmlGeneratorConfig {
   nonce: string;
   serveUrl: string;
+  serveCommand: string;
   webPartsJson: string;
   extensionsJson?: string;
   cspSource: string;
@@ -116,6 +117,7 @@ function generateScripts(config: IHtmlGeneratorConfig): string {
   // Prepare configuration object to inject
   const workbenchConfig = {
     serveUrl: config.serveUrl,
+    serveCommand: config.serveCommand,
     webParts: webParts,
     extensions: extensions,
     theme: config.currentTheme,

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -29,6 +29,8 @@ export interface IHtmlGeneratorConfig {
   contextSettings?: Partial<IContextConfig>;
   // Whether the API proxy is enabled (default true)
   proxyEnabled?: boolean;
+  // Whether opening the property pane should shrink the canvas (default true)
+  propertyPaneShrinkCanvas?: boolean;
   // External dependencies resolved from the SPFx project's node_modules
   externalDependencies?: IExternalDependency[];
 }
@@ -124,6 +126,7 @@ function generateScripts(config: IHtmlGeneratorConfig): string {
     customThemes: config.customThemes ?? [],
     context: config.contextSettings,
     proxyEnabled: config.proxyEnabled !== false,
+    propertyPaneShrinkCanvas: config.propertyPaneShrinkCanvas !== false,
     externalDependencies: (config.externalDependencies || []).map((dep) => ({
       moduleName: dep.moduleName,
       globalName: dep.globalName,

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -93,7 +93,7 @@ function generateStatusBar(
     <div class="status-bar">
         <div class="status-indicator">
             <div class="status-dot" id="status-dot"></div>
-            <span id="status-text">Initializing...</span>
+            <div id="status-text">Initializing...</div>
         </div>
         <span id="component-count">${countText}</span>
         <div class="separator"></div>

--- a/src/workbench/types/IWebviewMessage.ts
+++ b/src/workbench/types/IWebviewMessage.ts
@@ -6,6 +6,8 @@ export interface IWebviewMessage {
     | 'refresh'
     | 'setServeUrl'
     | 'openDevTools'
+    | 'openSettings'
+    | 'startServe'
     | 'log'
     | 'error'
     | 'vscodeThemeColors'

--- a/webview/src/WorkbenchRuntime.ts
+++ b/webview/src/WorkbenchRuntime.ts
@@ -598,6 +598,14 @@ export class WorkbenchRuntime {
     this.vscode.postMessage({ command: 'mockDataMenu' });
   }
 
+  handleStartServe(): void {
+    this.vscode.postMessage({ command: 'startServe' });
+  }
+
+  handleOpenSettings(): void {
+    this.vscode.postMessage({ command: 'openSettings' });
+  }
+
   private updateStatus(message: string): void {
     const loadingStatus = document.getElementById('loading-status');
     const statusText = document.getElementById('status-text');

--- a/webview/src/components/App/App.module.css
+++ b/webview/src/components/App/App.module.css
@@ -4,6 +4,12 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding-right: 0;
+  transition: padding-right 0.2s ease;
+
+  &.panelOpen {
+    padding-right: 340px;
+  }
 }
 
 .loading {

--- a/webview/src/components/App/App.tsx
+++ b/webview/src/components/App/App.tsx
@@ -32,7 +32,7 @@ export interface IAppHandlers {
   updateWebPartProperties: (instanceId: string, properties: any) => void;
 }
 
-export const App: FC<IAppProps> = ({ config: _config, onInitialized }) => {
+export const App: FC<IAppProps> = ({ config, onInitialized }) => {
   const [manifests, setManifests] = useState<IComponentManifest[]>([]);
   const [activeWebParts, setActiveWebParts] = useState<IWebPartConfig[]>([]);
   const [activeExtensions, setActiveExtensions] = useState<IExtensionConfig[]>([]);
@@ -68,9 +68,11 @@ export const App: FC<IAppProps> = ({ config: _config, onInitialized }) => {
     onInitialized(handlers);
   }, [onInitialized]);
 
+  const shrinkCanvas = config.propertyPaneShrinkCanvas !== false;
+
   return (
     <ErrorBoundary>
-      <div className={styles.workbenchApp}>
+      <div className={css(styles.workbenchApp, shrinkCanvas && selectedWebPart && styles.panelOpen)}>
         {/* Application Customizer Header Placeholder */}
         <div
           id="app-customizer-header"

--- a/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
+++ b/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
@@ -1,10 +1,9 @@
-import { IconButton, PrimaryButton, Separator, Stack, Text } from '@fluentui/react';
+import { Panel, PanelType, PrimaryButton, Separator, Stack, Text } from '@fluentui/react';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { PropertyPaneFieldType, logger } from '@spfx-local-workbench/shared';
 import type { IActiveWebPart } from '@spfx-local-workbench/shared';
 
-import styles from './PropertyPanePanel.module.css';
 import {
   ButtonComponent,
   CheckboxComponent,
@@ -90,29 +89,30 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
 
   const hasPendingChanges = Object.keys(pendingChanges).length > 0;
 
-  return (
-    <div
-      id="property-pane"
-      className={`${styles.panel} ${webPart ? styles.open : ''}`}
-      style={{ display: 'flex', flexDirection: 'column' }}
-    >
-      <Stack
-        horizontal
-        horizontalAlign="space-between"
-        verticalAlign="center"
-        styles={{ root: { padding: '12px 16px', flexShrink: 0 } }}
-      >
-        <Text variant="large" styles={{ root: { fontWeight: 600 } }}>
-          {webPart?.manifest.alias ?? 'Properties'}
-        </Text>
-        <IconButton
-          iconProps={{ iconName: 'Cancel' }}
-          title="Close"
-          ariaLabel="Close"
-          onClick={onClose}
+  const renderFooter = isNonReactive
+    ? () => (
+        <PrimaryButton
+          text="Apply"
+          onClick={handleApply}
+          disabled={!hasPendingChanges}
+          styles={{ root: { width: 'fit-content' } }}
         />
-      </Stack>
-      <div id="property-pane-content" style={{ flex: 1, overflowY: 'auto' }}>
+      )
+    : undefined;
+
+  return (
+    <Panel
+      id="property-pane"
+      isOpen={!!webPart}
+      type={PanelType.custom}
+      customWidth="340px"
+      headerText={webPart?.manifest.alias ?? 'Properties'}
+      onDismiss={onClose}
+      isBlocking={false}
+      isFooterAtBottom={isNonReactive}
+      onRenderFooterContent={renderFooter}
+    >
+      <div id="property-pane-content">
         {config && config.pages && config.pages.length > 0 && webPart ? (
           <PropertyPaneContent
             config={config}
@@ -128,17 +128,7 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
           </Stack>
         )}
       </div>
-      {isNonReactive && (
-        <Stack styles={{ root: { padding: '12px 16px', flexShrink: 0 } }}>
-          <PrimaryButton
-            text="Apply"
-            onClick={handleApply}
-            disabled={!hasPendingChanges}
-            styles={{ root: { width: 'fit-content' } }}
-          />
-        </Stack>
-      )}
-    </div>
+    </Panel>
   );
 };
 

--- a/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
+++ b/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
@@ -1,5 +1,5 @@
-import { IconButton, Separator, Stack, Text } from '@fluentui/react';
-import React, { FC, useEffect, useState } from 'react';
+import { IconButton, PrimaryButton, Separator, Stack, Text } from '@fluentui/react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { PropertyPaneFieldType, logger } from '@spfx-local-workbench/shared';
 import type { IActiveWebPart } from '@spfx-local-workbench/shared';
@@ -32,6 +32,15 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
 }) => {
   const [config, setConfig] = useState<any>(null);
 
+  // Check if the web part has disabled reactive property changes
+  const isNonReactive =
+    webPart?.instance &&
+    'disableReactivePropertyChanges' in webPart.instance &&
+    (webPart.instance as any).disableReactivePropertyChanges === true;
+
+  // Buffer for pending property changes in non-reactive mode
+  const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
+
   useEffect(() => {
     if (webPart?.instance && typeof webPart.instance.getPropertyPaneConfiguration === 'function') {
       try {
@@ -44,15 +53,54 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
     } else {
       setConfig(null);
     }
+    // Reset pending changes when web part changes
+    setPendingChanges({});
   }, [webPart]);
 
+  // Handle property change - either buffer it or apply it immediately
+  const handlePropertyChange = useCallback(
+    (targetProperty: string, newValue: any) => {
+      if (isNonReactive) {
+        setPendingChanges((prev) => ({ ...prev, [targetProperty]: newValue }));
+      } else {
+        onPropertyChange(targetProperty, newValue);
+      }
+    },
+    [isNonReactive, onPropertyChange],
+  );
+
+  // Apply all pending changes
+  const handleApply = useCallback(() => {
+    Object.entries(pendingChanges).forEach(([targetProperty, newValue]) => {
+      onPropertyChange(targetProperty, newValue);
+    });
+    setPendingChanges({});
+  }, [pendingChanges, onPropertyChange]);
+
+  // Get the current value for a field (considering pending changes)
+  const getCurrentValue = useCallback(
+    (targetProperty: string) => {
+      if (isNonReactive && targetProperty in pendingChanges) {
+        return pendingChanges[targetProperty];
+      }
+      return targetProperty ? webPart?.properties[targetProperty] : undefined;
+    },
+    [isNonReactive, pendingChanges, webPart?.properties],
+  );
+
+  const hasPendingChanges = Object.keys(pendingChanges).length > 0;
+
   return (
-    <div id="property-pane" className={`${styles.panel} ${webPart ? styles.open : ''}`}>
+    <div
+      id="property-pane"
+      className={`${styles.panel} ${webPart ? styles.open : ''}`}
+      style={{ display: 'flex', flexDirection: 'column' }}
+    >
       <Stack
         horizontal
         horizontalAlign="space-between"
         verticalAlign="center"
-        styles={{ root: { padding: '12px 16px', borderBottom: '1px solid #edebe9' } }}
+        styles={{ root: { padding: '12px 16px', flexShrink: 0 } }}
       >
         <Text variant="large" styles={{ root: { fontWeight: 600 } }}>
           {webPart?.manifest.alias ?? 'Properties'}
@@ -64,12 +112,13 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
           onClick={onClose}
         />
       </Stack>
-      <div id="property-pane-content">
+      <div id="property-pane-content" style={{ flex: 1, overflowY: 'auto' }}>
         {config && config.pages && config.pages.length > 0 && webPart ? (
           <PropertyPaneContent
             config={config}
             webPart={webPart}
-            onPropertyChange={onPropertyChange}
+            onPropertyChange={handlePropertyChange}
+            getCurrentValue={getCurrentValue}
           />
         ) : (
           <Stack horizontalAlign="center" styles={{ root: { padding: '16px' } }}>
@@ -79,6 +128,16 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
           </Stack>
         )}
       </div>
+      {isNonReactive && (
+        <Stack styles={{ root: { padding: '12px 16px', flexShrink: 0 } }}>
+          <PrimaryButton
+            text="Apply"
+            onClick={handleApply}
+            disabled={!hasPendingChanges}
+            styles={{ root: { width: 'fit-content' } }}
+          />
+        </Stack>
+      )}
     </div>
   );
 };
@@ -87,12 +146,14 @@ interface IPropertyPaneContentProps {
   config: any;
   webPart: IActiveWebPart;
   onPropertyChange: (targetProperty: string, newValue: any) => void;
+  getCurrentValue: (targetProperty: string) => any;
 }
 
 const PropertyPaneContent: FC<IPropertyPaneContentProps> = ({
   config,
   webPart,
   onPropertyChange,
+  getCurrentValue,
 }) => {
   const page = config.pages[0];
 
@@ -102,12 +163,9 @@ const PropertyPaneContent: FC<IPropertyPaneContentProps> = ({
       {(page.groups || []).map((group: any, groupIndex: number) => (
         <Stack key={groupIndex} tokens={{ childrenGap: 12 }}>
           {!group.isGroupNameHidden && group.groupName && (
-            <>
-              <Text variant="mediumPlus" styles={{ root: { fontWeight: 600 } }}>
-                {group.groupName}
-              </Text>
-              <Separator />
-            </>
+            <Text variant="mediumPlus" styles={{ root: { fontWeight: 600 } }}>
+              {group.groupName}
+            </Text>
           )}
           <Stack tokens={{ childrenGap: 8 }}>
             {(group.groupFields || []).map((field: any, fieldIndex: number) => (
@@ -115,6 +173,7 @@ const PropertyPaneContent: FC<IPropertyPaneContentProps> = ({
                 key={fieldIndex}
                 field={field}
                 webPart={webPart}
+                currentValue={getCurrentValue(field.targetProperty)}
                 onPropertyChange={onPropertyChange}
               />
             ))}
@@ -128,16 +187,20 @@ const PropertyPaneContent: FC<IPropertyPaneContentProps> = ({
 interface IPropertyPaneFieldProps {
   field: any;
   webPart: IActiveWebPart;
+  currentValue: any;
   onPropertyChange: (targetProperty: string, newValue: any) => void;
 }
 
-const PropertyPaneField: FC<IPropertyPaneFieldProps> = ({ field, webPart, onPropertyChange }) => {
+const PropertyPaneField: FC<IPropertyPaneFieldProps> = ({
+  field,
+  webPart,
+  currentValue,
+  onPropertyChange,
+}) => {
   // Guard against null webPart
   if (!webPart) {
     return null;
   }
-
-  const currentValue = field.targetProperty ? webPart.properties[field.targetProperty] : undefined;
 
   const handleChange = (newValue: any) => {
     if (field.targetProperty) {

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
@@ -1,17 +1,5 @@
 /* WorkbenchCanvas component styles */
 
-:global {
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-
-    to {
-      transform: rotate(360deg);
-    }
-  }
-}
-
 .canvas {
   max-width: 1028px;
   margin: 0 auto;

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.module.css
@@ -1,5 +1,17 @@
 /* WorkbenchCanvas component styles */
 
+:global {
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}
+
 .canvas {
   max-width: 1028px;
   margin: 0 auto;

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
@@ -72,7 +72,10 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
           tokens={{ childrenGap: 16 }}
           styles={{ root: { padding: '24px' } }}
         >
-          <Text variant="large" styles={{ root: { color: '#a80000', marginBottom: 16 } }}>
+          <Text
+            variant="large"
+            styles={{ root: { color: '#a80000', marginBottom: 16, textAlign: 'center' } }}
+          >
             No SPFx components found. Make sure your project is served / running.
           </Text>
           <PrimaryButton

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
@@ -1,5 +1,5 @@
 import { IconButton, Link, PrimaryButton, Stack, Text } from '@fluentui/react';
-import React, { FC, Fragment, useMemo, useState } from 'react';
+import React, { FC, Fragment, useEffect, useMemo, useState } from 'react';
 
 import type {
   IComponentManifest,
@@ -57,6 +57,17 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
     setServeClicked(true);
     window.dispatchEvent(new CustomEvent('startServe'));
   };
+
+  // Re-enable the Serve button after a timeout so the user can retry if the
+  // serve command fails. On success the manifests will load and this empty
+  // state unmounts entirely, so the reset is only relevant on failure.
+  useEffect(() => {
+    if (!serveClicked) {
+      return;
+    }
+    const timer = setTimeout(() => setServeClicked(false), 30_000);
+    return () => clearTimeout(timer);
+  }, [serveClicked]);
 
   const handleOpenSettings = () => {
     window.dispatchEvent(new CustomEvent('openSettings'));

--- a/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
+++ b/webview/src/components/WorkbenchCanvas/WorkbenchCanvas.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Stack, Text } from '@fluentui/react';
+import { IconButton, Link, PrimaryButton, Stack, Text } from '@fluentui/react';
 import React, { FC, Fragment, useMemo, useState } from 'react';
 
 import type {
@@ -34,6 +34,7 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
   locale,
 }) => {
   const [openPickerIndex, setOpenPickerIndex] = useState<number | null>(null);
+  const [serveClicked, setServeClicked] = useState(false);
 
   const handleAddClick = (insertIndex: number) => {
     setOpenPickerIndex(openPickerIndex === insertIndex ? null : insertIndex);
@@ -52,13 +53,58 @@ export const WorkbenchCanvas: FC<IWorkbenchCanvasProps> = ({
     setOpenPickerIndex(null);
   };
 
+  const handleStartServe = () => {
+    setServeClicked(true);
+    window.dispatchEvent(new CustomEvent('startServe'));
+  };
+
+  const handleOpenSettings = () => {
+    window.dispatchEvent(new CustomEvent('openSettings'));
+  };
+
   if (manifests.length === 0) {
+    const serveCommand = window.__workbenchConfig?.serveCommand || 'heft start --clean --nobrowser';
+
     return (
       <div id="canvas">
-        <Stack horizontalAlign="center" styles={{ root: { padding: '24px' } }}>
-          <Text variant="large" styles={{ root: { color: '#a80000' } }}>
+        <Stack
+          horizontalAlign="center"
+          tokens={{ childrenGap: 16 }}
+          styles={{ root: { padding: '24px' } }}
+        >
+          <Text variant="large" styles={{ root: { color: '#a80000', marginBottom: 16 } }}>
             No SPFx components found. Make sure your project is served / running.
           </Text>
+          <PrimaryButton
+            text="Serve"
+            onClick={handleStartServe}
+            disabled={serveClicked}
+            iconProps={serveClicked ? { iconName: 'Sync' } : undefined}
+            styles={
+              serveClicked
+                ? {
+                    icon: {
+                      animation: 'spin 1.5s linear infinite',
+                    },
+                  }
+                : undefined
+            }
+          />
+          <Stack
+            horizontal
+            tokens={{ childrenGap: 4 }}
+            styles={{ root: { alignItems: 'flex-end' } }}
+          >
+            <Text variant="small" styles={{ root: { color: '#605e5c', marginRight: 4 } }}>
+              Command:
+            </Text>
+            <Text variant="small" styles={{ root: { fontFamily: 'monospace', color: '#323130' } }}>
+              {serveCommand}
+            </Text>
+          </Stack>
+          <Link onClick={handleOpenSettings} styles={{ root: { fontSize: 12 } }}>
+            Open Extension Settings
+          </Link>
         </Stack>
       </div>
     );

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -95,6 +95,14 @@ function initialize() {
       runtime.handleMockData();
     }) as EventListener);
 
+    window.addEventListener('startServe', (() => {
+      runtime.handleStartServe();
+    }) as EventListener);
+
+    window.addEventListener('openSettings', (() => {
+      runtime.handleOpenSettings();
+    }) as EventListener);
+
     // Listen for live reload messages from the extension
     window.addEventListener('message', (event: MessageEvent) => {
       const message = event.data;

--- a/webview/src/styles/global.css
+++ b/webview/src/styles/global.css
@@ -96,8 +96,16 @@ body {
   background: #d13438;
 }
 
-#status-text,
+#status-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 #component-count {
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/webview/src/styles/global.css
+++ b/webview/src/styles/global.css
@@ -16,6 +16,7 @@ body {
   background-color: var(--primaryBackground, white);
   height: auto;
   min-height: 100vh;
+  min-width: 364px;
   overflow-y: auto;
 }
 
@@ -65,6 +66,7 @@ body {
   font-size: 12px;
   color: var(--neutralSecondary, #605e5c);
   z-index: 100;
+  white-space: nowrap;
 }
 
 .status-bar .separator {
@@ -79,10 +81,12 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .status-dot {
   width: 8px;
+  min-width: 8px;
   height: 8px;
   border-radius: 50%;
   background: #107c10;
@@ -90,4 +94,17 @@ body {
 
 .status-dot.disconnected {
   background: #d13438;
+}
+
+#status-text,
+#component-count {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 500px) {
+  .status-bar {
+    padding: 6px;
+  }
 }

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -25,6 +25,8 @@ export interface IWorkbenchConfig {
   customThemes?: ITheme[];
   context: IContextSettings; // Always provided by extension (from WorkbenchConfig defaults)
   proxyEnabled?: boolean;
+  /** When true, the canvas shrinks to make room when the property pane is open (default true). */
+  propertyPaneShrinkCanvas?: boolean;
   externalDependencies?: Array<{ moduleName: string; globalName: string }>;
 }
 

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -16,6 +16,7 @@ export interface IVsCodeApi {
 
 export interface IWorkbenchConfig {
   serveUrl: string;
+  serveCommand: string;
   webParts: IWebPartManifest[];
   extensions?: IExtensionManifest[];
   /** The active SharePoint theme. Comes from `spfxLocalWorkbench.theme.current` (+ custom). */


### PR DESCRIPTION
- Fixes the non-reactive property pane setting
- Makes the property pane shrink the canvas by default (matches pages/online workbench) but provides a setting to use the overlay option instead
---

This pull request introduces several improvements to the configuration and UI logic for the SPFx Local Workbench, focusing on enhanced settings organization, improved documentation, and better UI consistency. The most significant changes include the addition of new configuration options (notably for property pane behavior), improved documentation for configuration fields, and updated coding standards for UI components.

**Configuration Enhancements:**

* Added explicit `order` fields to all configuration properties in `package.json` to control their display sequence in the VS Code settings UI. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R246-R264) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R278) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R292) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R313) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R345-R351) [[6]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R521) [[7]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R634-R670) [[8]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R689-R710) [[9]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R728-R752) [[10]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R761)
* Introduced a new `propertyPane.shrinkCanvas` setting under a new "Workbench" group, allowing users to control whether the canvas shrinks when the property pane is open. This is reflected in the configuration, code, and localized descriptions. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R689-R710) [[2]](diffhunk://#diff-0810ad2f2b1d67bc65abcc921e27084b5a02efb6b7aee66b1c9330fb4ac6dfb4R28) [[3]](diffhunk://#diff-0810ad2f2b1d67bc65abcc921e27084b5a02efb6b7aee66b1c9330fb4ac6dfb4R39) [[4]](diffhunk://#diff-0810ad2f2b1d67bc65abcc921e27084b5a02efb6b7aee66b1c9330fb4ac6dfb4R59-R62) [[5]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fR437) [[6]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L142-R144) [[7]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L143-R145)

**Documentation and Localization Improvements:**

* Enhanced descriptions for several configuration options, including clarifying the `storybook.storiesPattern` as relative to the workspace root, in both English and French localizations. [[1]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L120-R120) [[2]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L121-R121)
* Added localized strings for the new "Workbench" group and `propertyPane.shrinkCanvas` setting. [[1]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L142-R144) [[2]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L143-R145)

**UI and Code Quality Improvements:**

* Updated the UI coding standards documentation to require the use of Fluent UI's `css()` utility for combining CSS module classes, ensuring cleaner and more robust component styling.
* Minor code formatting and parameter ordering improvements in `WorkbenchPanel.ts` for better readability and maintainability. [[1]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fL8-R8) [[2]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fL88-R91) [[3]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fL131-R138)

**Command and Extension Metadata Updates:**

* Changed the extension ID in the settings command from `BeauCameron.spfx-local-workbench` to `thechriskent.spfx-local-workbench` to reflect the current extension ownership.

**Feature Additions:**

* Added support for new webview messages (`openSettings`, `startServe`) in `WorkbenchPanel.ts`, enabling the UI to trigger these actions via VS Code commands.
* Passed the `serveCommand` and `propertyPaneShrinkCanvas` settings through to the workbench HTML generator for use in the webview. [[1]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fR424) [[2]](diffhunk://#diff-3a87b520b8316564e87e9214d8a8da816c5a15f699a1f6d5b090c233a3642113R15) [[3]](diffhunk://#diff-069d611f8a4aaa4992a68d7dbe719bdb9386faafb125babb5c9d4a043ca65e8fR437)