### PR TITLE
Storybook edit commands

### DIFF
--- a/packages/storybook-addon-spfx/src/preview.ts
+++ b/packages/storybook-addon-spfx/src/preview.ts
@@ -199,6 +199,11 @@ if (typeof window !== 'undefined') {
         return;
       }
 
+      // All incoming control messages originate from the parent (manager) frame.
+      if (event.source !== window.parent) {
+        return;
+      }
+
       if (
         data.type === 'spfx:paste' &&
         data.target === 'preview' &&
@@ -221,6 +226,11 @@ if (typeof window !== 'undefined') {
 
       // Context menu command dispatched from the outer webview overlay.
       if (data.type === 'spfx:contextCmd' && data.target === 'preview') {
+        const knownCmds = ['copy', 'cut', 'paste', 'selectAll', 'undo', 'redo'] as const;
+        type KnownCmd = (typeof knownCmds)[number];
+        if (!knownCmds.includes(data.cmd as KnownCmd)) {
+          return;
+        }
         switch (data.cmd) {
           case 'copy': {
             const saved = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement | null;

--- a/packages/storybook-addon-spfx/src/preview.ts
+++ b/packages/storybook-addon-spfx/src/preview.ts
@@ -106,7 +106,9 @@ if (typeof window !== 'undefined') {
       'contextmenu',
       (e: MouseEvent) => {
         e.preventDefault();
-        contextMenuActiveEl = document.activeElement as HTMLElement;
+        const target = e.target as HTMLElement;
+        contextMenuActiveEl =
+          (target.closest('input, textarea, [contenteditable]') as HTMLElement | null) ?? target;
         const el = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement;
         const hasSelection =
           el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'

--- a/packages/storybook-addon-spfx/src/preview.ts
+++ b/packages/storybook-addon-spfx/src/preview.ts
@@ -30,3 +30,244 @@ export const parameters = {
     showPropertyPane: false,
   },
 };
+
+// Clipboard and selection relay for VS Code webview context.
+// When running inside VS Code, the clipboard API is blocked in nested cross-origin iframes.
+// We intercept CMD+C/V/X/A/Z and relay clipboard operations via the extension API.
+if (typeof window !== 'undefined') {
+  // Detect VS Code context synchronously by probing window.top.
+  // In VS Code, window.top is the outer vscode-webview:// context (cross-origin),
+  // so accessing its properties throws a SecurityError.
+  // In a regular browser, window.top is http://localhost:6006 (same-origin), no error.
+  let isVSCodeContext = false;
+  try {
+    void window.top?.location.href;
+  } catch {
+    isVSCodeContext = true;
+  }
+
+  if (isVSCodeContext) {
+    // Save the focused element at CMD+V / right-click time so async responses (the
+    // clipboard relay round-trip) target the correct input even if focus has shifted.
+    let pendingPasteTarget: HTMLElement | null = null;
+    let contextMenuActiveEl: HTMLElement | null = null;
+
+    // --- Clipboard helpers ---
+    const getSelectedText = (): string => {
+      const el = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+        return el.value.substring(el.selectionStart ?? 0, el.selectionEnd ?? 0);
+      }
+      return window.getSelection()?.toString() ?? '';
+    };
+
+    const cutSelectedText = (): string => {
+      const el = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+        const start = el.selectionStart ?? 0;
+        const end = el.selectionEnd ?? 0;
+        const text = el.value.substring(start, end);
+        if (start !== end) {
+          el.value = el.value.slice(0, start) + el.value.slice(end);
+          el.selectionStart = el.selectionEnd = start;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        return text;
+      }
+      const sel = window.getSelection()?.toString() ?? '';
+      if (sel) {
+        document.execCommand('delete');
+      }
+      return sel;
+    };
+
+    // --- Focus notification ---
+    // When a canvas editable element gains focus, notify the manager frame so it can
+    // update `lastActiveFrame`. This ensures the VS Code keybinding fallback (CMD+V
+    // after clicking the panel title) routes to the canvas, not the Storybook UI.
+    document.addEventListener(
+      'focusin',
+      (e: FocusEvent) => {
+        const target = e.target as HTMLElement;
+        if (
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable
+        ) {
+          window.parent.postMessage({ type: 'spfx:previewFocused' }, '*');
+        }
+      },
+      true,
+    );
+
+    // --- Context menu interception ---
+    document.addEventListener(
+      'contextmenu',
+      (e: MouseEvent) => {
+        e.preventDefault();
+        contextMenuActiveEl = document.activeElement as HTMLElement;
+        const el = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement;
+        const hasSelection =
+          el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'
+            ? (el.selectionStart ?? 0) !== (el.selectionEnd ?? 0)
+            : !!window.getSelection()?.toString();
+        const isEditable = !!(
+          el.tagName === 'INPUT' ||
+          el.tagName === 'TEXTAREA' ||
+          contextMenuActiveEl.isContentEditable
+        );
+        // Relay to manager, which adjusts coordinates and relays to the outer webview.
+        window.parent.postMessage(
+          {
+            type: 'spfx:contextMenu',
+            target: 'preview',
+            x: e.clientX,
+            y: e.clientY,
+            hasSelection,
+            isEditable,
+          },
+          '*',
+        );
+      },
+      true,
+    );
+
+    // --- Keyboard interception ---
+    // Shortcuts that need relay (clipboard blocked in VS Code cross-origin iframes):
+    //   CMD+V  paste    — relay clipboard read via extension
+    //   CMD+C  copy     — relay clipboard write via extension
+    //   CMD+X  cut      — relay clipboard write via extension
+    // Shortcuts handled directly (no clipboard access needed):
+    //   CMD+A  select-all
+    //   CMD+Z  undo
+    //   CMD+Shift+Z (Mac) / Ctrl+Shift+Z / Ctrl+Y (Windows) — redo
+    // Platform detection: Mac uses CMD (metaKey); Windows uses Ctrl (ctrlKey).
+    // We never treat Ctrl as a shortcut modifier on Mac — those are separate OS-level bindings.
+    const isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+    window.addEventListener(
+      'keydown',
+      (e: KeyboardEvent) => {
+        const isShortcut = isMac ? e.metaKey : e.ctrlKey;
+        if (!isShortcut) {
+          return;
+        }
+        const key = e.key.toLowerCase();
+        // y (Ctrl+Y redo) is a Windows-only convention; CMD+Y has no standard meaning on Mac.
+        if (!['v', 'c', 'x', 'a', 'z', ...(!isMac ? ['y'] : [])].includes(key)) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        switch (key) {
+          case 'v':
+            pendingPasteTarget = document.activeElement as HTMLElement;
+            window.parent.postMessage({ type: 'spfx:clipboardRequest', target: 'preview' }, '*');
+            break;
+          case 'c': {
+            const text = getSelectedText();
+            if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+            break;
+          }
+          case 'x': {
+            const text = cutSelectedText();
+            if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+            break;
+          }
+          case 'a':
+            document.execCommand('selectAll');
+            break;
+          case 'z':
+            document.execCommand(e.shiftKey ? 'redo' : 'undo');
+            break;
+          case 'y':
+            document.execCommand('redo');
+            break;
+        }
+      },
+      true,
+    );
+
+    window.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data as {
+        type?: string;
+        text?: string;
+        target?: string;
+        cmd?: string;
+      } | null;
+      if (!data || typeof data !== 'object') {
+        return;
+      }
+
+      if (
+        data.type === 'spfx:paste' &&
+        data.target === 'preview' &&
+        typeof data.text === 'string'
+      ) {
+        const el = pendingPasteTarget ?? (document.activeElement as HTMLElement);
+        pendingPasteTarget = null;
+        if (el) {
+          el.focus();
+        }
+        // execCommand('insertText') fires synthetic input events that React observes.
+        document.execCommand('insertText', false, data.text);
+        return;
+      }
+
+      if (data.type === 'spfx:selectAll' && data.target === 'preview') {
+        document.execCommand('selectAll');
+        return;
+      }
+
+      // Context menu command dispatched from the outer webview overlay.
+      if (data.type === 'spfx:contextCmd' && data.target === 'preview') {
+        switch (data.cmd) {
+          case 'copy': {
+            const saved = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement | null;
+            const text =
+              saved && (saved.tagName === 'INPUT' || saved.tagName === 'TEXTAREA')
+                ? saved.value.substring(saved.selectionStart ?? 0, saved.selectionEnd ?? 0)
+                : (window.getSelection()?.toString() ?? '');
+            if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+            break;
+          }
+          case 'cut': {
+            if (contextMenuActiveEl) {
+              contextMenuActiveEl.focus();
+            }
+            const text = cutSelectedText();
+            if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+            break;
+          }
+          case 'paste':
+            // Focus the saved element before the async clipboard round-trip so that
+            // execCommand('insertText') lands in the right input when the response arrives.
+            if (contextMenuActiveEl) {
+              contextMenuActiveEl.focus();
+            }
+            pendingPasteTarget = contextMenuActiveEl;
+            window.parent.postMessage({ type: 'spfx:clipboardRequest', target: 'preview' }, '*');
+            break;
+          case 'selectAll':
+            if (contextMenuActiveEl) {
+              contextMenuActiveEl.focus();
+            }
+            document.execCommand('selectAll');
+            break;
+          case 'undo':
+            if (contextMenuActiveEl) {
+              contextMenuActiveEl.focus();
+            }
+            document.execCommand('undo');
+            break;
+          case 'redo':
+            if (contextMenuActiveEl) {
+              contextMenuActiveEl.focus();
+            }
+            document.execCommand('redo');
+            break;
+        }
+      }
+    });
+  }
+}

--- a/samples/v1.22.2/Storybook/src/webparts/helloStorybook/components/HelloStorybook.tsx
+++ b/samples/v1.22.2/Storybook/src/webparts/helloStorybook/components/HelloStorybook.tsx
@@ -4,7 +4,7 @@ import type { IHelloStorybookProps } from './IHelloStorybookProps';
 import { ThemePreview } from './ThemePreview/ThemePreview';
 import { DisplayModeIndicator } from './DisplayModeIndicator/DisplayModeIndicator';
 import * as strings from 'HelloStorybookWebPartStrings';
-import { css } from '@fluentui/react';
+import { css, TextField } from '@fluentui/react';
 
 export default class HelloStorybook extends React.Component<IHelloStorybookProps> {
   public render(): React.ReactElement<IHelloStorybookProps> {
@@ -37,6 +37,11 @@ export default class HelloStorybook extends React.Component<IHelloStorybookProps
         <div className={css(styles.section, styles.horizontal)}>
           <div className={styles.sectionTitle}>Display Mode:</div>
           <DisplayModeIndicator displayMode={displayMode} />
+        </div>
+        <div className={css(styles.section, styles.horizontal)}>
+          <div className={styles.sectionTitle}>Input Test:</div>
+          <input type="text" placeholder="Standard input..." />
+          <TextField placeholder="FluentUI input..."/>
         </div>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>Theme:</div>

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -381,7 +381,7 @@ export class StorybookPanel {
             color: var(--vscode-menu-foreground, #cccccc);
             cursor: pointer; white-space: nowrap; gap: 24px;
         }
-        .cm-item:hover { background: var(--vscode-list-hoverBackground, #2a2d2e); }
+        .cm-item:hover, .cm-item:focus { background: var(--vscode-list-hoverBackground, #2a2d2e); outline: none; }
         .cm-item.disabled { opacity: 0.4; pointer-events: none; }
         .cm-hint { color: var(--vscode-descriptionForeground, #858585); font-size: 12px; }
         .cm-sep { height: 1px; background: var(--vscode-menu-separatorBackground, #3c3c3c); margin: 4px 0; }
@@ -397,13 +397,13 @@ export class StorybookPanel {
     <iframe id="storybook-frame" src="${storybookUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"></iframe>
     <div id="spfx-cm-backdrop"></div>
     <div id="spfx-cm" role="menu">
-      <div class="cm-item" id="cm-undo">      <span>Undo</span>       <span class="cm-hint" id="hint-undo"></span></div>
-      <div class="cm-item" id="cm-redo">      <span>Redo</span>       <span class="cm-hint" id="hint-redo"></span></div>
-      <div class="cm-sep"></div>
-      <div class="cm-item" id="cm-cut">       <span>Cut</span>        <span class="cm-hint" id="hint-cut"></span></div>
-      <div class="cm-item" id="cm-copy">      <span>Copy</span>       <span class="cm-hint" id="hint-copy"></span></div>
-      <div class="cm-item" id="cm-paste">     <span>Paste</span>      <span class="cm-hint" id="hint-paste"></span></div>
-      <div class="cm-item" id="cm-select-all"><span>Select All</span> <span class="cm-hint" id="hint-select-all"></span></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-undo">      <span>Undo</span>       <span class="cm-hint" id="hint-undo"></span></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-redo">      <span>Redo</span>       <span class="cm-hint" id="hint-redo"></span></div>
+      <div class="cm-sep" role="separator"></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-cut">       <span>Cut</span>        <span class="cm-hint" id="hint-cut"></span></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-copy">      <span>Copy</span>       <span class="cm-hint" id="hint-copy"></span></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-paste">     <span>Paste</span>      <span class="cm-hint" id="hint-paste"></span></div>
+      <div class="cm-item" role="menuitem" tabindex="-1" id="cm-select-all"><span>Select All</span> <span class="cm-hint" id="hint-select-all"></span></div>
     </div>
     <script nonce="${nonce}">
       var vscode = acquireVsCodeApi();
@@ -427,20 +427,28 @@ export class StorybookPanel {
         backdrop.style.display = 'none';
       }
 
+      function setItemDisabled(id, disabled) {
+        var el = document.getElementById(id);
+        el.classList.toggle('disabled', disabled);
+        el.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      }
+
       function showMenu(x, y, target, hasSelection, isEditable) {
         cmTarget = target;
-        document.getElementById('cm-cut').classList.toggle('disabled', !hasSelection || !isEditable);
-        document.getElementById('cm-copy').classList.toggle('disabled', !hasSelection);
-        document.getElementById('cm-undo').classList.toggle('disabled', !isEditable);
-        document.getElementById('cm-redo').classList.toggle('disabled', !isEditable);
-        document.getElementById('cm-select-all').classList.toggle('disabled', !isEditable);
+        setItemDisabled('cm-cut',        !hasSelection || !isEditable);
+        setItemDisabled('cm-copy',       !hasSelection);
+        setItemDisabled('cm-undo',       !isEditable);
+        setItemDisabled('cm-redo',       !isEditable);
+        setItemDisabled('cm-select-all', !isEditable);
         // Show backdrop first so any click (including inside the iframe) is captured.
         backdrop.style.display = 'block';
         cm.style.left = '0'; cm.style.top = '0'; cm.style.display = 'block';
-        // Clamp to viewport after measuring actual size.
+        // Clamp to viewport after measuring actual size, then move focus into the menu.
         requestAnimationFrame(function() {
           cm.style.left = Math.min(x, window.innerWidth  - cm.offsetWidth  - 4) + 'px';
           cm.style.top  = Math.min(y, window.innerHeight - cm.offsetHeight - 4) + 'px';
+          var first = cm.querySelector('[role="menuitem"]:not([aria-disabled="true"])');
+          if (first) { first.focus(); }
         });
       }
 
@@ -448,7 +456,21 @@ export class StorybookPanel {
       // the menu on any click that doesn't land on a menu item.
       backdrop.addEventListener('mousedown', hideMenu);
       document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') { hideMenu(); }
+        if (e.key === 'Escape') { hideMenu(); return; }
+        if (cm.style.display === 'none') { return; }
+        var items = Array.prototype.slice.call(cm.querySelectorAll('[role="menuitem"]:not([aria-disabled="true"])'));
+        if (!items.length) { return; }
+        var idx = items.indexOf(document.activeElement);
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          items[(idx + 1) % items.length].focus();
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          items[(idx - 1 + items.length) % items.length].focus();
+        } else if ((e.key === 'Enter' || e.key === ' ') && idx !== -1) {
+          e.preventDefault();
+          document.activeElement.click();
+        }
       });
 
       function cmAction(cmd) {

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -136,9 +136,10 @@ export class StorybookPanel {
     this.panel.webview.onDidReceiveMessage(
       async (message: { type?: string; target?: string; text?: string }) => {
         if (message.type === 'spfx:clipboardRequest') {
-          const target = message.target === 'preview' || message.target === 'manager'
-            ? message.target
-            : 'manager';
+          const target =
+            message.target === 'preview' || message.target === 'manager'
+              ? message.target
+              : 'manager';
           const text = await vscode.env.clipboard.readText();
           void this.panel.webview.postMessage({ type: 'spfx:paste', text, target });
         } else if (message.type === 'spfx:clipboardWrite' && typeof message.text === 'string') {
@@ -441,6 +442,7 @@ export class StorybookPanel {
         cmTarget = target;
         setItemDisabled('cm-cut',        !hasSelection || !isEditable);
         setItemDisabled('cm-copy',       !hasSelection);
+        setItemDisabled('cm-paste',      !isEditable);
         setItemDisabled('cm-undo',       !isEditable);
         setItemDisabled('cm-redo',       !isEditable);
         setItemDisabled('cm-select-all', !isEditable);

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -467,11 +467,17 @@ export class StorybookPanel {
       window.addEventListener('message', function(e) {
         var data = e.data;
         if (!data || typeof data !== 'object') { return; }
+        // Only trust iframe-originated message types when they actually come from the frame.
+        // Extension-originated types (spfx:paste, spfx:selectAll) skip this check.
+        var fromFrame = e.source === frame.contentWindow;
         if (data.type === 'spfx:clipboardRequest') {
+          if (!fromFrame) { return; }
           vscode.postMessage({ type: 'spfx:clipboardRequest', target: data.target });
         } else if (data.type === 'spfx:clipboardWrite') {
+          if (!fromFrame) { return; }
           vscode.postMessage({ type: 'spfx:clipboardWrite', text: data.text });
         } else if (data.type === 'spfx:contextMenu') {
+          if (!fromFrame) { return; }
           showMenu(data.x, data.y, data.target, data.hasSelection, data.isEditable);
         } else if (data.type === 'spfx:paste' || data.type === 'spfx:selectAll') {
           frame.contentWindow.postMessage(data, '*');

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -136,9 +136,12 @@ export class StorybookPanel {
     this.panel.webview.onDidReceiveMessage(
       async (message: { type?: string; target?: string; text?: string }) => {
         if (message.type === 'spfx:clipboardRequest') {
+          const target = message.target === 'preview' || message.target === 'manager'
+            ? message.target
+            : 'manager';
           const text = await vscode.env.clipboard.readText();
-          void this.panel.webview.postMessage({ type: 'spfx:paste', text, target: message.target });
-        } else if (message.type === 'spfx:clipboardWrite' && message.text !== undefined) {
+          void this.panel.webview.postMessage({ type: 'spfx:paste', text, target });
+        } else if (message.type === 'spfx:clipboardWrite' && typeof message.text === 'string') {
           await vscode.env.clipboard.writeText(message.text);
         }
       },
@@ -427,6 +430,7 @@ export class StorybookPanel {
         backdrop.style.display = 'none';
       }
 
+      /** Makes them look disabled and marks them disabled for screen readers n stuff */
       function setItemDisabled(id, disabled) {
         var el = document.getElementById(id);
         el.classList.toggle('disabled', disabled);

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { escapeHtml, getErrorMessage } from '@spfx-local-workbench/shared';
+import { getNonce } from '@spfx-local-workbench/shared/utils/node';
 
 import { SpfxProjectDetector } from '../SpfxProjectDetector';
 import type { IStorybookThemeColors } from '../types';
@@ -131,7 +132,7 @@ export class StorybookPanel {
     // Handle clipboard requests from Storybook — Storybook intercepts CMD+V/CTRL+V in the
     // cross-origin iframe (where VS Code keybindings never fire) and relays the request
     // here. The extension reads the clipboard via the VS Code API and sends the text back.
-    // Also handles clipboard writes (copy/cut) and contextCmd routing.
+    // Also handles clipboard writes (copy/cut operations forwarded from the iframe).
     this.panel.webview.onDidReceiveMessage(
       async (message: { type?: string; target?: string; text?: string }) => {
         if (message.type === 'spfx:clipboardRequest') {
@@ -350,6 +351,7 @@ export class StorybookPanel {
    */
   private getStorybookHtml(): string {
     const storybookUrl = this.serverManager.getUrl();
+    const nonce = getNonce();
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -359,7 +361,7 @@ export class StorybookPanel {
           content="default-src 'none'; 
                    frame-src ${storybookUrl} http://localhost:* ws://localhost:*; 
                    style-src 'unsafe-inline';
-                   script-src 'unsafe-inline';">
+                   script-src 'nonce-${nonce}';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SPFx Storybook</title>
     <style>
@@ -403,7 +405,7 @@ export class StorybookPanel {
       <div class="cm-item" id="cm-paste">     <span>Paste</span>      <span class="cm-hint" id="hint-paste"></span></div>
       <div class="cm-item" id="cm-select-all"><span>Select All</span> <span class="cm-hint" id="hint-select-all"></span></div>
     </div>
-    <script>
+    <script nonce="${nonce}">
       var vscode = acquireVsCodeApi();
       var frame = document.getElementById('storybook-frame');
       var cm = document.getElementById('spfx-cm');

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -127,6 +127,23 @@ export class StorybookPanel {
       null,
       this.disposables,
     );
+
+    // Handle clipboard requests from Storybook — Storybook intercepts CMD+V/CTRL+V in the
+    // cross-origin iframe (where VS Code keybindings never fire) and relays the request
+    // here. The extension reads the clipboard via the VS Code API and sends the text back.
+    // Also handles clipboard writes (copy/cut) and contextCmd routing.
+    this.panel.webview.onDidReceiveMessage(
+      async (message: { type?: string; target?: string; text?: string }) => {
+        if (message.type === 'spfx:clipboardRequest') {
+          const text = await vscode.env.clipboard.readText();
+          void this.panel.webview.postMessage({ type: 'spfx:paste', text, target: message.target });
+        } else if (message.type === 'spfx:clipboardWrite' && message.text !== undefined) {
+          await vscode.env.clipboard.writeText(message.text);
+        }
+      },
+      undefined,
+      this.disposables,
+    );
   }
 
   /**
@@ -341,25 +358,126 @@ export class StorybookPanel {
     <meta http-equiv="Content-Security-Policy" 
           content="default-src 'none'; 
                    frame-src ${storybookUrl} http://localhost:* ws://localhost:*; 
-                   style-src 'unsafe-inline';">
+                   style-src 'unsafe-inline';
+                   script-src 'unsafe-inline';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SPFx Storybook</title>
     <style>
-        body {
-            margin: 0;
-            padding: 0;
-            overflow: hidden;
-            background-color: var(--vscode-editor-background);
+        body { margin: 0; padding: 0; overflow: hidden; background-color: var(--vscode-editor-background); }
+        iframe { width: 100%; height: 100vh; border: none; }
+        #spfx-cm {
+            display: none; position: fixed; z-index: 9999;
+            background: var(--vscode-menu-background, #252526);
+            border: 1px solid var(--vscode-menu-border, #3c3c3c);
+            border-radius: 4px; padding: 4px 0; min-width: 200px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.4); user-select: none;
         }
-        iframe {
-            width: 100%;
-            height: 100vh;
-            border: none;
+        .cm-item {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 5px 12px; font-size: 13px;
+            font-family: var(--vscode-font-family, -apple-system, sans-serif);
+            color: var(--vscode-menu-foreground, #cccccc);
+            cursor: pointer; white-space: nowrap; gap: 24px;
+        }
+        .cm-item:hover { background: var(--vscode-list-hoverBackground, #2a2d2e); }
+        .cm-item.disabled { opacity: 0.4; pointer-events: none; }
+        .cm-hint { color: var(--vscode-descriptionForeground, #858585); font-size: 12px; }
+        .cm-sep { height: 1px; background: var(--vscode-menu-separatorBackground, #3c3c3c); margin: 4px 0; }
+        /* Transparent full-screen backdrop. Sits above the iframe (pointer-events
+           would otherwise never reach the outer document from a cross-origin iframe)
+           but below the menu so item clicks still work. Shown only while menu is open. */
+        #spfx-cm-backdrop {
+            display: none; position: fixed; inset: 0; z-index: 9998;
         }
     </style>
 </head>
 <body>
-    <iframe src="${storybookUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"></iframe>
+    <iframe id="storybook-frame" src="${storybookUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"></iframe>
+    <div id="spfx-cm-backdrop"></div>
+    <div id="spfx-cm" role="menu">
+      <div class="cm-item" id="cm-undo">      <span>Undo</span>       <span class="cm-hint" id="hint-undo"></span></div>
+      <div class="cm-item" id="cm-redo">      <span>Redo</span>       <span class="cm-hint" id="hint-redo"></span></div>
+      <div class="cm-sep"></div>
+      <div class="cm-item" id="cm-cut">       <span>Cut</span>        <span class="cm-hint" id="hint-cut"></span></div>
+      <div class="cm-item" id="cm-copy">      <span>Copy</span>       <span class="cm-hint" id="hint-copy"></span></div>
+      <div class="cm-item" id="cm-paste">     <span>Paste</span>      <span class="cm-hint" id="hint-paste"></span></div>
+      <div class="cm-item" id="cm-select-all"><span>Select All</span> <span class="cm-hint" id="hint-select-all"></span></div>
+    </div>
+    <script>
+      var vscode = acquireVsCodeApi();
+      var frame = document.getElementById('storybook-frame');
+      var cm = document.getElementById('spfx-cm');
+      var backdrop = document.getElementById('spfx-cm-backdrop');
+      var cmTarget = 'manager';
+
+      // Detect platform to show the correct keyboard shortcut hints.
+      var isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+      var mod = isMac ? '⌘ ' : 'Ctrl+';
+      document.getElementById('hint-undo').textContent       = mod + 'Z';
+      document.getElementById('hint-redo').textContent       = isMac ? '⇧ ⌘ Z' : 'Ctrl+Y';
+      document.getElementById('hint-cut').textContent        = mod + 'X';
+      document.getElementById('hint-copy').textContent       = mod + 'C';
+      document.getElementById('hint-paste').textContent      = mod + 'V';
+      document.getElementById('hint-select-all').textContent = mod + 'A';
+
+      function hideMenu() {
+        cm.style.display = 'none';
+        backdrop.style.display = 'none';
+      }
+
+      function showMenu(x, y, target, hasSelection, isEditable) {
+        cmTarget = target;
+        document.getElementById('cm-cut').classList.toggle('disabled', !hasSelection || !isEditable);
+        document.getElementById('cm-copy').classList.toggle('disabled', !hasSelection);
+        document.getElementById('cm-undo').classList.toggle('disabled', !isEditable);
+        document.getElementById('cm-redo').classList.toggle('disabled', !isEditable);
+        document.getElementById('cm-select-all').classList.toggle('disabled', !isEditable);
+        // Show backdrop first so any click (including inside the iframe) is captured.
+        backdrop.style.display = 'block';
+        cm.style.left = '0'; cm.style.top = '0'; cm.style.display = 'block';
+        // Clamp to viewport after measuring actual size.
+        requestAnimationFrame(function() {
+          cm.style.left = Math.min(x, window.innerWidth  - cm.offsetWidth  - 4) + 'px';
+          cm.style.top  = Math.min(y, window.innerHeight - cm.offsetHeight - 4) + 'px';
+        });
+      }
+
+      // The backdrop covers the entire viewport (including the iframe) and dismisses
+      // the menu on any click that doesn't land on a menu item.
+      backdrop.addEventListener('mousedown', hideMenu);
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') { hideMenu(); }
+      });
+
+      function cmAction(cmd) {
+        // All context menu actions (including paste) go through spfx:contextCmd so the
+        // iframe can restore focus to the saved element before the async clipboard
+        // round-trip begins. Paste is no longer sent directly to the extension here.
+        frame.contentWindow.postMessage({ type: 'spfx:contextCmd', cmd: cmd, target: cmTarget }, '*');
+        hideMenu();
+      }
+
+      document.getElementById('cm-cut').onclick        = function() { cmAction('cut'); };
+      document.getElementById('cm-copy').onclick       = function() { cmAction('copy'); };
+      document.getElementById('cm-paste').onclick      = function() { cmAction('paste'); };
+      document.getElementById('cm-undo').onclick       = function() { cmAction('undo'); };
+      document.getElementById('cm-redo').onclick       = function() { cmAction('redo'); };
+      document.getElementById('cm-select-all').onclick = function() { cmAction('selectAll'); };
+
+      window.addEventListener('message', function(e) {
+        var data = e.data;
+        if (!data || typeof data !== 'object') { return; }
+        if (data.type === 'spfx:clipboardRequest') {
+          vscode.postMessage({ type: 'spfx:clipboardRequest', target: data.target });
+        } else if (data.type === 'spfx:clipboardWrite') {
+          vscode.postMessage({ type: 'spfx:clipboardWrite', text: data.text });
+        } else if (data.type === 'spfx:contextMenu') {
+          showMenu(data.x, data.y, data.target, data.hasSelection, data.isEditable);
+        } else if (data.type === 'spfx:paste' || data.type === 'spfx:selectAll') {
+          frame.contentWindow.postMessage(data, '*');
+        }
+      });
+    </script>
 </body>
 </html>`;
   }

--- a/src/workbench/storybook/StorybookServerManager.ts
+++ b/src/workbench/storybook/StorybookServerManager.ts
@@ -331,6 +331,10 @@ export class StorybookServerManager {
    * flattens all referenced body files into public/proxy/ with unique names.
    */
   private async copyMockFiles(): Promise<void> {
+    // Storybook's main.ts always declares staticDirs: ['../public'], so the directory must exist!
+    const publicDir = path.join(this.storybookDir, 'public');
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(publicDir));
+
     // Read proxy settings to get the mock file location
     const proxySettings = ApiProxyService.readSettings();
 

--- a/src/workbench/storybook/templates/manager.ts
+++ b/src/workbench/storybook/templates/manager.ts
@@ -249,22 +249,32 @@ if (window !== window.top) {
       return;
     }
 
+    // Determine the expected sender for each message type:
+    // preview-frame-originated messages must come from the canvas iframe;
+    // parent-originated messages (spfx:paste, spfx:selectAll, spfx:contextCmd) must come from window.parent.
+    const fromPreview = event.source === getPreviewFrame()?.contentWindow;
+    const fromParent  = event.source === window.parent;
+
     if (data.type === 'spfx:previewFocused') {
+      if (!fromPreview) { return; }
       lastActiveFrame = 'preview';
       return;
     }
 
     // Relay clipboard/context requests from the preview frame up to the outer webview.
     if (data.type === 'spfx:clipboardRequest' && data.target === 'preview') {
+      if (!fromPreview) { return; }
       window.parent.postMessage(data, '*');
       return;
     }
     if (data.type === 'spfx:clipboardWrite') {
+      if (!fromPreview) { return; }
       // Relay copy/cut result from preview up to the outer webview.
       window.parent.postMessage(data, '*');
       return;
     }
     if (data.type === 'spfx:contextMenu' && data.target === 'preview') {
+      if (!fromPreview) { return; }
       // Adjust the preview-relative mouse coordinates to manager document coordinates.
       const pf = getPreviewFrame();
       const rect = pf?.getBoundingClientRect();
@@ -280,6 +290,7 @@ if (window !== window.top) {
     }
 
     if (data.type === 'spfx:paste' && typeof data.text === 'string') {
+      if (!fromParent) { return; }
       const target = data.target ?? lastActiveFrame;
       if (target === 'manager') {
         // Restore focus to the element that initiated the paste (context menu or CMD+V/CTRL+V).
@@ -294,6 +305,7 @@ if (window !== window.top) {
     }
 
     if (data.type === 'spfx:selectAll') {
+      if (!fromParent) { return; }
       const target = data.target ?? lastActiveFrame;
       if (target === 'manager') {
         document.execCommand('selectAll');
@@ -305,6 +317,7 @@ if (window !== window.top) {
 
     // Context menu command dispatched from the outer webview overlay.
     if (data.type === 'spfx:contextCmd') {
+      if (!fromParent) { return; }
       const target =
         data.cmd === 'paste' ? (data.target ?? lastActiveFrame) : (data.target ?? 'manager');
 

--- a/src/workbench/storybook/templates/manager.ts
+++ b/src/workbench/storybook/templates/manager.ts
@@ -51,3 +51,316 @@ style.innerHTML = `
   }
 `;
 document.head.appendChild(style);
+
+// --- VS Code context detection ---
+// The Storybook manager is the top-level window when opened in a browser.
+// When loaded inside VS Code, the extension embeds it in a cross-origin iframe, so
+// `window !== window.top` is a zero-dependency, zero-timing-risk way to detect VS Code.
+// This avoids the previous approach of waiting for a `spfx:vscodeContext` postMessage,
+// which arrived before manager.ts's listener was registered (Storybook loads async).
+if (window !== window.top) {
+  // --- Clipboard helpers ---
+  /** Returns selected text from the focused input or the document selection. */
+  const getSelectedText = (): string => {
+    const el = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+      return el.value.substring(el.selectionStart ?? 0, el.selectionEnd ?? 0);
+    }
+    return window.getSelection()?.toString() ?? '';
+  };
+
+  /** Removes and returns selected text from the focused input. */
+  const cutSelectedText = (): string => {
+    const el = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+      const start = el.selectionStart ?? 0;
+      const end = el.selectionEnd ?? 0;
+      const text = el.value.substring(start, end);
+      if (start !== end) {
+        el.value = el.value.slice(0, start) + el.value.slice(end);
+        el.selectionStart = el.selectionEnd = start;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      return text;
+    }
+    const sel = window.getSelection()?.toString() ?? '';
+    if (sel) {
+      document.execCommand('delete');
+    }
+    return sel;
+  };
+
+  // --- Context menu state ---
+  // Save the active element at right-click time so context menu actions can
+  // operate on it even after focus shifts to the context menu overlay.
+  let contextMenuActiveEl: HTMLElement | null = null;
+
+  const getPreviewFrame = (): HTMLIFrameElement | null =>
+    (document.getElementById('storybook-preview-iframe') ??
+      document.querySelector('iframe')) as HTMLIFrameElement | null;
+
+  // --- Focus tracking ---
+  // Track whether the user's focus is in the manager UI or the preview canvas.
+  // Used when the VS Code keybinding fallback fires (after clicking the panel title)
+  // to route paste to the correct frame without double-pasting.
+  //
+  // Two signals update this:
+  //   1. `focusin` on the manager document: when an IFRAME element gets focus, the
+  //      canvas is active; any other element means manager UI is active.
+  //   2. `spfx:previewFocused` from preview.ts: canvas input explicitly notifies us.
+  let lastActiveFrame: 'manager' | 'preview' = 'manager';
+
+  document.addEventListener(
+    'focusin',
+    (e: FocusEvent) => {
+      lastActiveFrame = (e.target as HTMLElement).tagName === 'IFRAME' ? 'preview' : 'manager';
+    },
+    true,
+  );
+
+  // --- Relay spfx:vscodeContext to the preview iframe ---
+  // preview.ts detects VS Code context synchronously via window.top cross-origin check,
+  // but we still send this as a belt-and-suspenders fallback for any edge cases.
+  // Re-send on each `load` because Storybook reloads the preview iframe per story.
+  const relayContextToPreview = (frame: HTMLIFrameElement) => {
+    frame.contentWindow?.postMessage({ type: 'spfx:vscodeContext' }, '*');
+    frame.addEventListener('load', () => {
+      frame.contentWindow?.postMessage({ type: 'spfx:vscodeContext' }, '*');
+    });
+  };
+
+  const initialPreviewFrame = getPreviewFrame();
+  if (initialPreviewFrame) {
+    relayContextToPreview(initialPreviewFrame);
+  } else {
+    const observer = new MutationObserver((_m, obs) => {
+      const frame = getPreviewFrame();
+      if (frame) {
+        obs.disconnect();
+        relayContextToPreview(frame);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  // --- Context menu interception ---
+  // Prevent the browser/VS Code default context menu and show our custom one instead,
+  // which correctly routes actions back through the clipboard relay chain.
+  document.addEventListener(
+    'contextmenu',
+    (e: MouseEvent) => {
+      // Let the preview iframe handle its own context menu via its own listener;
+      // events don't cross iframe boundaries so this fires only for manager UI elements.
+      e.preventDefault();
+      contextMenuActiveEl = document.activeElement as HTMLElement;
+      const el = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement;
+      const hasSelection =
+        el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'
+          ? (el.selectionStart ?? 0) !== (el.selectionEnd ?? 0)
+          : !!window.getSelection()?.toString();
+      const isEditable = !!(
+        el.tagName === 'INPUT' ||
+        el.tagName === 'TEXTAREA' ||
+        (contextMenuActiveEl as HTMLElement).isContentEditable
+      );
+      window.parent.postMessage(
+        {
+          type: 'spfx:contextMenu',
+          target: 'manager',
+          x: e.clientX,
+          y: e.clientY,
+          hasSelection,
+          isEditable,
+        },
+        '*',
+      );
+    },
+    true,
+  );
+
+  // --- Keyboard interception ---
+  // Shortcuts that need relay (clipboard blocked in VS Code cross-origin iframes):
+  //   CMD+V/CTRL+V  paste    — relay clipboard read via extension
+  //   CMD+C/CTRL+C  copy     — relay clipboard write via extension
+  //   CMD+X/CTRL+X  cut      — relay clipboard write via extension
+  // Shortcuts handled directly (no clipboard access needed):
+  //   CMD+A/CTRL+A  select-all
+  //   CMD+Z/CTRL+Z  undo
+  //   CMD+Shift+Z (Mac) / Ctrl+Shift+Z / Ctrl+Y (Windows) — redo
+  // Platform detection: Mac uses CMD (metaKey); Windows uses Ctrl (ctrlKey).
+  // We never treat Ctrl as a shortcut modifier on Mac — those are separate OS-level bindings.
+  const isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+  window.addEventListener(
+    'keydown',
+    (e: KeyboardEvent) => {
+      const isShortcut = isMac ? e.metaKey : e.ctrlKey;
+      if (!isShortcut) {
+        return;
+      }
+      const key = e.key.toLowerCase();
+      // y (Ctrl+Y redo) is a Windows-only convention; CMD+Y has no standard meaning on Mac.
+      if (!['v', 'c', 'x', 'a', 'z', ...(!isMac ? ['y'] : [])].includes(key)) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      switch (key) {
+        case 'v':
+          window.parent.postMessage({ type: 'spfx:clipboardRequest', target: 'manager' }, '*');
+          break;
+        case 'c': {
+          const text = getSelectedText();
+          if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+          break;
+        }
+        case 'x': {
+          const text = cutSelectedText();
+          if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+          break;
+        }
+        case 'a':
+          document.execCommand('selectAll');
+          break;
+        case 'z':
+          document.execCommand(e.shiftKey ? 'redo' : 'undo');
+          break;
+        case 'y':
+          document.execCommand('redo');
+          break;
+      }
+    },
+    true,
+  );
+
+  // --- Message handling ---
+  window.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data as {
+      type?: string;
+      text?: string;
+      target?: string;
+      x?: number;
+      y?: number;
+      hasSelection?: boolean;
+      isEditable?: boolean;
+      cmd?: string;
+    } | null;
+    if (!data || typeof data !== 'object') {
+      return;
+    }
+
+    if (data.type === 'spfx:previewFocused') {
+      lastActiveFrame = 'preview';
+      return;
+    }
+
+    // Relay clipboard/context requests from the preview frame up to the outer webview.
+    if (data.type === 'spfx:clipboardRequest' && data.target === 'preview') {
+      window.parent.postMessage(data, '*');
+      return;
+    }
+    if (data.type === 'spfx:clipboardWrite') {
+      // Relay copy/cut result from preview up to the outer webview.
+      window.parent.postMessage(data, '*');
+      return;
+    }
+    if (data.type === 'spfx:contextMenu' && data.target === 'preview') {
+      // Adjust the preview-relative mouse coordinates to manager document coordinates.
+      const pf = getPreviewFrame();
+      const rect = pf?.getBoundingClientRect();
+      window.parent.postMessage(
+        {
+          ...data,
+          x: (data.x ?? 0) + (rect?.left ?? 0),
+          y: (data.y ?? 0) + (rect?.top ?? 0),
+        },
+        '*',
+      );
+      return;
+    }
+
+    if (data.type === 'spfx:paste' && typeof data.text === 'string') {
+      const target = data.target ?? lastActiveFrame;
+      if (target === 'manager') {
+        // Restore focus to the element that initiated the paste (context menu or CMD+V/CTRL+V).
+        if (contextMenuActiveEl) {
+          contextMenuActiveEl.focus();
+        }
+        document.execCommand('insertText', false, data.text);
+      } else {
+        getPreviewFrame()?.contentWindow?.postMessage(data, '*');
+      }
+      return;
+    }
+
+    if (data.type === 'spfx:selectAll') {
+      const target = data.target ?? lastActiveFrame;
+      if (target === 'manager') {
+        document.execCommand('selectAll');
+      } else {
+        getPreviewFrame()?.contentWindow?.postMessage(data, '*');
+      }
+      return;
+    }
+
+    // Context menu command dispatched from the outer webview overlay.
+    if (data.type === 'spfx:contextCmd') {
+      const target =
+        data.cmd === 'paste' ? (data.target ?? lastActiveFrame) : (data.target ?? 'manager');
+
+      if (target === 'preview') {
+        // Forward to the canvas; preview.ts handles it.
+        getPreviewFrame()?.contentWindow?.postMessage(data, '*');
+        return;
+      }
+
+      // Handle in the manager frame.
+      switch (data.cmd) {
+        case 'copy': {
+          // Use the saved element so focus doesn't need to be restored for reads.
+          const saved = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement | null;
+          const text =
+            saved && (saved.tagName === 'INPUT' || saved.tagName === 'TEXTAREA')
+              ? saved.value.substring(saved.selectionStart ?? 0, saved.selectionEnd ?? 0)
+              : (window.getSelection()?.toString() ?? '');
+          if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+          break;
+        }
+        case 'cut': {
+          if (contextMenuActiveEl) {
+            contextMenuActiveEl.focus();
+          }
+          const text = cutSelectedText();
+          if (text) window.parent.postMessage({ type: 'spfx:clipboardWrite', text }, '*');
+          break;
+        }
+        case 'paste':
+          // Focus the saved element first so execCommand('insertText') lands in the
+          // right place when the async clipboard response arrives.
+          if (contextMenuActiveEl) {
+            contextMenuActiveEl.focus();
+          }
+          window.parent.postMessage({ type: 'spfx:clipboardRequest', target: 'manager' }, '*');
+          break;
+        case 'selectAll':
+          if (contextMenuActiveEl) {
+            contextMenuActiveEl.focus();
+          }
+          document.execCommand('selectAll');
+          break;
+        case 'undo':
+          if (contextMenuActiveEl) {
+            contextMenuActiveEl.focus();
+          }
+          document.execCommand('undo');
+          break;
+        case 'redo':
+          if (contextMenuActiveEl) {
+            contextMenuActiveEl.focus();
+          }
+          document.execCommand('redo');
+          break;
+      }
+    }
+  });
+}

--- a/src/workbench/storybook/templates/manager.ts
+++ b/src/workbench/storybook/templates/manager.ts
@@ -95,6 +95,10 @@ if (window !== window.top) {
   // Save the active element at right-click time so context menu actions can
   // operate on it even after focus shifts to the context menu overlay.
   let contextMenuActiveEl: HTMLElement | null = null;
+  // Set to true when the context-menu "Paste" command initiates a clipboard request,
+  // so the async spfx:paste response knows to restore focus to contextMenuActiveEl.
+  // Keyboard CMD/CTRL+V pastes must NOT restore focus to a stale context-menu target.
+  let pendingContextMenuPaste = false;
 
   const getPreviewFrame = (): HTMLIFrameElement | null =>
     (document.getElementById('storybook-preview-iframe') ??
@@ -153,7 +157,9 @@ if (window !== window.top) {
       // Let the preview iframe handle its own context menu via its own listener;
       // events don't cross iframe boundaries so this fires only for manager UI elements.
       e.preventDefault();
-      contextMenuActiveEl = document.activeElement as HTMLElement;
+      const target = e.target as HTMLElement;
+      contextMenuActiveEl =
+        (target.closest('input, textarea, [contenteditable]') as HTMLElement | null) ?? target;
       const el = contextMenuActiveEl as HTMLInputElement | HTMLTextAreaElement;
       const hasSelection =
         el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'
@@ -303,10 +309,13 @@ if (window !== window.top) {
       }
       const target = data.target ?? lastActiveFrame;
       if (target === 'manager') {
-        // Restore focus to the element that initiated the paste (context menu or CMD+V/CTRL+V).
-        if (contextMenuActiveEl) {
+        // Only restore focus to contextMenuActiveEl when this paste was triggered by the
+        // context menu. Keyboard paste (CMD/CTRL+V) must not hijack focus to a stale
+        // context-menu target.
+        if (pendingContextMenuPaste && contextMenuActiveEl) {
           contextMenuActiveEl.focus();
         }
+        pendingContextMenuPaste = false;
         document.execCommand('insertText', false, data.text);
       } else {
         getPreviewFrame()?.contentWindow?.postMessage(data, '*');
@@ -367,6 +376,7 @@ if (window !== window.top) {
           if (contextMenuActiveEl) {
             contextMenuActiveEl.focus();
           }
+          pendingContextMenuPaste = true;
           window.parent.postMessage({ type: 'spfx:clipboardRequest', target: 'manager' }, '*');
           break;
         case 'selectAll':

--- a/src/workbench/storybook/templates/manager.ts
+++ b/src/workbench/storybook/templates/manager.ts
@@ -253,28 +253,36 @@ if (window !== window.top) {
     // preview-frame-originated messages must come from the canvas iframe;
     // parent-originated messages (spfx:paste, spfx:selectAll, spfx:contextCmd) must come from window.parent.
     const fromPreview = event.source === getPreviewFrame()?.contentWindow;
-    const fromParent  = event.source === window.parent;
+    const fromParent = event.source === window.parent;
 
     if (data.type === 'spfx:previewFocused') {
-      if (!fromPreview) { return; }
+      if (!fromPreview) {
+        return;
+      }
       lastActiveFrame = 'preview';
       return;
     }
 
     // Relay clipboard/context requests from the preview frame up to the outer webview.
     if (data.type === 'spfx:clipboardRequest' && data.target === 'preview') {
-      if (!fromPreview) { return; }
+      if (!fromPreview) {
+        return;
+      }
       window.parent.postMessage(data, '*');
       return;
     }
     if (data.type === 'spfx:clipboardWrite') {
-      if (!fromPreview) { return; }
+      if (!fromPreview) {
+        return;
+      }
       // Relay copy/cut result from preview up to the outer webview.
       window.parent.postMessage(data, '*');
       return;
     }
     if (data.type === 'spfx:contextMenu' && data.target === 'preview') {
-      if (!fromPreview) { return; }
+      if (!fromPreview) {
+        return;
+      }
       // Adjust the preview-relative mouse coordinates to manager document coordinates.
       const pf = getPreviewFrame();
       const rect = pf?.getBoundingClientRect();
@@ -290,7 +298,9 @@ if (window !== window.top) {
     }
 
     if (data.type === 'spfx:paste' && typeof data.text === 'string') {
-      if (!fromParent) { return; }
+      if (!fromParent) {
+        return;
+      }
       const target = data.target ?? lastActiveFrame;
       if (target === 'manager') {
         // Restore focus to the element that initiated the paste (context menu or CMD+V/CTRL+V).
@@ -305,7 +315,9 @@ if (window !== window.top) {
     }
 
     if (data.type === 'spfx:selectAll') {
-      if (!fromParent) { return; }
+      if (!fromParent) {
+        return;
+      }
       const target = data.target ?? lastActiveFrame;
       if (target === 'manager') {
         document.execCommand('selectAll');
@@ -317,7 +329,9 @@ if (window !== window.top) {
 
     // Context menu command dispatched from the outer webview overlay.
     if (data.type === 'spfx:contextCmd') {
-      if (!fromParent) { return; }
+      if (!fromParent) {
+        return;
+      }
       const target =
         data.cmd === 'paste' ? (data.target ?? lastActiveFrame) : (data.target ?? 'manager');
 

--- a/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
+++ b/webview/src/components/PropertyPanePanel/PropertyPanePanel.tsx
@@ -111,6 +111,7 @@ export const PropertyPanePanel: FC<IPropertyPanePanelProps> = ({
       isBlocking={false}
       isFooterAtBottom={isNonReactive}
       onRenderFooterContent={renderFooter}
+      layerProps={{ eventBubblingEnabled: true }}
     >
       <div id="property-pane-content">
         {config && config.pages && config.pages.length > 0 && webPart ? (


### PR DESCRIPTION
Storybook runs in an iframe within a webview panel and then loads stories inside a nested iframe. The way VS Code captures keyboard commands prevents them from flowing through to the underlying iframes because of how it detects focused elements. This sets up a cross-platform relay system for paste, cut, copy, selectAll, undo, and redo. It also adds a custom context menu for these commands. Wowee!

---
This pull request introduces a comprehensive solution for clipboard and context menu support in Storybook when running inside the VS Code webview. It enables seamless copy, cut, paste, and selection operations—despite browser clipboard API restrictions in cross-origin iframes—by relaying these actions through the VS Code extension. Additionally, it adds a custom context menu overlay that mimics native browser menus and ensures accessibility of editing shortcuts. Minor UI and test input improvements are also included.

**Clipboard and Context Menu Integration for VS Code Webview:**

* [`packages/storybook-addon-spfx/src/preview.ts`](diffhunk://#diff-e2ec451fc2cce341f7d0c94b9fdbf7d05cabee134fb5bc086a116bbfd08c42c2R33-R273): Implements clipboard and selection relay logic for Storybook running in VS Code, intercepting keyboard shortcuts (CMD/CTRL+C/V/X/A/Z/Y) and context menu actions, and relaying them to the extension for cross-origin clipboard access.
* [`src/workbench/storybook/StorybookPanel.ts`](diffhunk://#diff-7807f178344098d687ac47f973aac52a4b6cbd4eca96dd005b9e16834a6c381aR130-R146): Handles clipboard read/write requests from the Storybook iframe and relays context menu commands, using the VS Code API to access the clipboard securely.

**Custom Context Menu UI Overlay:**

* [`src/workbench/storybook/StorybookPanel.ts`](diffhunk://#diff-7807f178344098d687ac47f973aac52a4b6cbd4eca96dd005b9e16834a6c381aL344-R480): Adds a custom context menu overlay (HTML/CSS/JS) above the Storybook iframe, supporting undo, redo, cut, copy, paste, and select all, with correct keyboard shortcut hints and platform detection. Menu actions are routed to the appropriate target in the iframe.

**Developer Experience Improvements:**

* [`samples/v1.22.2/Storybook/src/webparts/helloStorybook/components/HelloStorybook.tsx`](diffhunk://#diff-ccadedd2739d3bcdf6ad79c9d6191acd2d0158b67ed3c5c750b86f26dc63b6d9L7-R7): Adds both a standard `<input>` and a FluentUI `<TextField>` to the sample web part, allowing for easy testing of clipboard and selection behavior in Storybook. [[1]](diffhunk://#diff-ccadedd2739d3bcdf6ad79c9d6191acd2d0158b67ed3c5c750b86f26dc63b6d9L7-R7) [[2]](diffhunk://#diff-ccadedd2739d3bcdf6ad79c9d6191acd2d0158b67ed3c5c750b86f26dc63b6d9R41-R45)

**Robustness Fix:**

* [`src/workbench/storybook/StorybookServerManager.ts`](diffhunk://#diff-e00982b4aec5265443e0a7182cf047b05eb92f4da57707f07a84596995918616R334-R337): Ensures the `public` directory always exists for Storybook static assets, preventing errors when serving files.