### PR TITLE
Html field security

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,6 @@ vsc-extension-quickstart.md
 **/*.ts
 !dist/templates/*.ts
 **/.vscode-test.*
+AGENTS.md
+.nvmrc
+.prettierignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,55 @@ npm install
 npm run compile
 ```
 
+## Publishing NPM Packages
+
+The extension version in the root `package.json` is the source of truth for the publishable packages in `packages/shared` and `packages/storybook-addon-spfx`.
+
+Use these scripts from the repo root:
+
+```bash
+# Bump the root extension version and synchronize both package manifests
+npm run version:bump:patch
+
+# Or minor / major
+npm run version:bump:minor
+npm run version:bump:major
+
+# If you set the root version manually, resync without bumping
+npm run version:sync
+
+# Verify the package versions are aligned before publishing
+npm run version:check
+
+# Build and publish shared first, then the Storybook addon
+npm run packages:publish
+```
+
+Notes:
+
+- `packages:publish` publishes `@spfx-local-workbench/shared` before `@spfx-local-workbench/storybook-addon-spfx` so the addon can resolve the newly published shared version.
+- The repo root package is marked `private`, and root `npm publish` is explicitly blocked, so an accidental publish from the extension root fails with a clear message instead of publishing the VS Code extension package to npm.
+- The Storybook addon dependency on `@spfx-local-workbench/shared` is updated automatically to match the synchronized version while preserving the existing version prefix such as `^`.
+- Run `npm login` first for the npm account that owns these packages. If your npm account uses 2FA for publishes, npm will prompt for the one-time code during `npm run packages:publish`.
+- `npm version ... --no-git-tag-version` updates the root manifest without creating a commit or git tag; tag and release however you prefer afterward.
+- If you want to verify the publish targets without pushing anything, run `node scripts/publish-packages.mjs --dry-run` after a build.
+
+## Publishing The VS Code Extension
+
+The VS Code extension is packaged locally and then uploaded manually to the `m365pnp` publisher in the Marketplace.
+
+From the repo root:
+
+```bash
+vsce package
+```
+
+Notes:
+
+- `vsce package` uses the root extension manifest and runs the existing `vscode:prepublish` step before generating the `.vsix` file.
+- The generated `.vsix` file uses the extension version from the root `package.json`.
+- To publish the updated extension to `m365pnp`, go to https://marketplace.visualstudio.com/manage/publishers/m365pnp?noPrompt=true, open the three-dots menu next to the extension, choose `Update`, and upload the generated `.vsix` file.
+
 ## Sample SPFx Projects
 
 If you keep test SPFx projects under `samples/`, they are excluded from VSIX packaging and VS Code search to keep the extension lean. The folder is still visible in the explorer. For the most reliable detection and debugging, open a sample project folder directly in its own VS Code window (or Extension Host) when testing.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,3 +31,13 @@ heft trust-dev-cert
 ```
 
 For more details, see the [official documentation](https://learn.microsoft.com/sharepoint/dev/spfx/set-up-your-development-environment#trusting-the-self-signed-developer-certificate).
+
+## YouTube (and other video embeds) show Error 153 / "Video player configuration error"
+
+This is a known limitation of the local workbench.
+
+**Root cause**: YouTube requires a valid HTTPS `Referer` header for all embedded player requests (YouTube policy change, mid-2025). The VS Code webview runs at the `vscode-webview://` scheme rather than an HTTPS origin. Because browsers do not send a `Referer` header when navigating from a non-HTTPS page to an HTTPS URL (per the `strict-origin-when-cross-origin` default policy), the YouTube player never receives an identity it can verify, and returns Error 153 (`embedder.identity.missing.referrer`).
+
+**Why it works in the online SharePoint workbench**: SharePoint pages are served over HTTPS, so the browser automatically sends `https://tenant.sharepoint.com/…` as the Referer when the web part creates a YouTube iframe.
+
+**Workaround**: Test YouTube (and other video embeds that perform origin checking) in Storybook. Video embed playback that depends on a verified HTTPS embedding origin is not fixable at the workbench level without a significant architectural change (serving the workbench itself from an HTTPS origin).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spfx-local-workbench",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spfx-local-workbench",
-      "version": "0.0.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@spfx-local-workbench/shared": "file:./packages/shared",
@@ -30,6 +30,7 @@
         "prettier": "^3.8.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "rimraf": "^6.0.1",
         "subset-font": "^1.4.10",
         "typed-css-modules": "^0.9.1",
         "typescript": "^5.9.3",
@@ -3815,9 +3816,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4694,6 +4697,110 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -6117,7 +6224,7 @@
     },
     "packages/shared": {
       "name": "@spfx-local-workbench/shared",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.0.0"
@@ -7864,14 +7971,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "packages/shared/node_modules/minipass": {
-      "version": "7.1.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/shared/node_modules/mkdirp": {

--- a/package.json
+++ b/package.json
@@ -624,6 +624,71 @@
               }
             },
             "additionalProperties": true
+          },
+          "spfxLocalWorkbench.htmlFieldSecurity.policy": {
+            "order": 20,
+            "type": "string",
+            "default": "allowList",
+            "enum": [
+              "none",
+              "allowAll",
+              "allowList"
+            ],
+            "enumDescriptions": [
+              "%configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.none%",
+              "%configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowAll%",
+              "%configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowList%"
+            ],
+            "markdownDescription": "%configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.markdownDescription%"
+          },
+          "spfxLocalWorkbench.htmlFieldSecurity.allowedDomains": {
+            "order": 30,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "youtube.com",
+              "youtube-nocookie.com",
+              "player.vimeo.com",
+              "bing.com",
+              "office.microsoft.com",
+              "officeclient.microsoft.com",
+              "store.office.com",
+              "skydrive.live.com",
+              "powerbi.com",
+              "powerbigov.us",
+              "sway.com",
+              "docs.com",
+              "powerapps.com",
+              "flow.microsoft.com",
+              "powerapps.us",
+              "flow.microsoft.us",
+              "app.smartsheet.com",
+              "publish.smartsheet.com",
+              "www.slideshare.net",
+              "youtu.be",
+              "read.amazon.com",
+              "onedrive.live.com",
+              "www.microsoft.com",
+              "forms.office365.us",
+              "support.office.com",
+              "embed.ted.com",
+              "channel9.msdn.com",
+              "forms.office.com",
+              "videoplayercdn.osi.office.net",
+              "forms.microsoft.com",
+              "forms.osi.office365.us",
+              "sway.office.com",
+              "sway.cloud.microsoft",
+              "linkedin.com",
+              "web.yammer.com",
+              "customervoice.microsoft.com",
+              "loop.usercontent.microsoft",
+              "outlook.office365.com",
+              "engage.cloud.microsoft"
+            ],
+            "markdownDescription": "%configuration.spfxLocalWorkbench.htmlFieldSecurity.allowedDomains.mdDescription%"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "spfx-local-workbench",
+  "name": "pnp-spfx-local-workbench",
+  "private": true,
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.1.2",
-  "publisher": "thechriskent",
+  "version": "0.1.3",
+  "publisher": "m365pnp",
   "homepage": "https://pnp.github.io/",
   "author": {
     "name": "Beau Cameron",
@@ -42,7 +43,9 @@
     "SharePoint Framework",
     "Web Parts",
     "Workbench",
-    "Local Development"
+    "Local Development",
+    "PnP",
+    "M365 Developer Community"
   ],
   "activationEvents": [
     "workspaceContains:**/config/package-solution.json",
@@ -833,6 +836,7 @@
     ]
   },
   "scripts": {
+    "prepublishOnly": "node scripts/block-root-publish.mjs",
     "vscode:prepublish": "npm run package",
     "compile": "npm run packages:build && npm run check-types && npm run lint && npm run generate:css-types && npm-run-all compile:*",
     "compile:extension": "node esbuild.js",
@@ -851,6 +855,11 @@
     "format": "prettier --write \"src/**/*.ts\" \"webview/src/**/*.{ts,tsx}\" \"packages/*/src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"webview/src/**/*.{ts,tsx}\" \"packages/*/src/**/*.{ts,tsx}\"",
     "generate:icons": "node scripts/generateIcons.js",
+    "version:sync": "node scripts/sync-package-versions.mjs",
+    "version:check": "node scripts/sync-package-versions.mjs --check",
+    "version:bump:patch": "npm version patch --no-git-tag-version && npm run version:sync",
+    "version:bump:minor": "npm version minor --no-git-tag-version && npm run version:sync",
+    "version:bump:major": "npm version major --no-git-tag-version && npm run version:sync",
     "packages:build": "npm run packages:build:shared && npm run packages:build:addon",
     "packages:build:shared": "cd packages/shared && npm run build",
     "packages:build:addon": "cd packages/storybook-addon-spfx && npm run build",
@@ -859,6 +868,7 @@
     "packages:watch:addon": "cd packages/storybook-addon-spfx && npm run watch",
     "packages:clean": "rimraf packages/*/dist packages/*/temp",
     "packages:install": "cd packages/shared && npm install && cd ../storybook-addon-spfx && npm install",
+    "packages:publish": "npm run version:sync && npm run packages:build && node scripts/publish-packages.mjs",
     "clean:cache": "rimraf node_modules/.cache .storybook-cache",
     "clean:dist": "rimraf dist temp && npm run packages:clean",
     "clean": "npm run clean:cache && npm run clean:dist",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -113,6 +113,11 @@
   "configuration.spfxLocalWorkbench.context.pageContext.properties.cultureInfo.properties.currentCultureName.description": "Code de culture actuel (par ex. en-US, de-DE, fr-FR)",
   "configuration.spfxLocalWorkbench.context.pageContext.properties.isNoScriptEnabled.description": "Indique si NoScript est activé sur le site",
   "configuration.spfxLocalWorkbench.context.pageContext.properties.isSPO.description": "Indique si ceci est SharePoint Online (vs. sur site)",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.markdownDescription": "Contrôle quels domaines externes sont autorisés à intégrer des iframes dans le plan de travail. Reproduit le paramètre [Sécurité des champs HTML](https://learn.microsoft.com/fr-fr/sharepoint/dev/general-development/how-to-allow-iframes-in-sharepoint) de SharePoint.",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.none": "Aucun iframe de domaines externes n'est autorisé",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowAll": "Autoriser les iframes de n'importe quel domaine",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowList": "Autoriser uniquement les iframes des domaines listés dans `#spfxLocalWorkbench.htmlFieldSecurity.allowedDomains#`",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.allowedDomains.mdDescription": "Domaines autorisés à intégrer des iframes lorsque `#spfxLocalWorkbench.htmlFieldSecurity.policy#` est défini sur `allowList`. Correspond à la liste des domaines autorisés dans la Sécurité des champs HTML de SharePoint.",
 
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port du serveur de développement Storybook",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Workbench SPFx local",
+  "displayName": "Workbench SPFx local!",
   "description": "Un workbench local pour tester les composants WebPart SharePoint Framework (SPFx) sans déployer sur SharePoint",
   "icons.fluentui-testbeaker.description": "Test Beaker",
   "icons.fluentui-testbeakersolid.description": "Test Beaker solide",

--- a/package.nls.json
+++ b/package.nls.json
@@ -114,6 +114,11 @@
   "configuration.spfxLocalWorkbench.context.pageContext.properties.cultureInfo.properties.currentCultureName.description": "Current culture code (e.g., en-US, de-DE, fr-FR)",
   "configuration.spfxLocalWorkbench.context.pageContext.properties.isNoScriptEnabled.description": "Whether NoScript is enabled on the site",
   "configuration.spfxLocalWorkbench.context.pageContext.properties.isSPO.description": "Whether this is SharePoint Online (vs. on-premises)",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.markdownDescription": "Controls which external domains are allowed to embed iframes in the workbench. Mirrors SharePoint's [HTML Field Security](https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-allow-iframes-in-sharepoint) setting.",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.none": "No iframes from external domains are allowed",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowAll": "Allow iframes from any domain",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.policy.enumDescriptions.allowList": "Allow iframes only from the domains listed in `#spfxLocalWorkbench.htmlFieldSecurity.allowedDomains#`",
+  "configuration.spfxLocalWorkbench.htmlFieldSecurity.allowedDomains.mdDescription": "Domains allowed to embed iframes when `#spfxLocalWorkbench.htmlFieldSecurity.policy#` is set to `allowList`. Matches SharePoint's HTML Field Security allowed domains list.",
 
   "configuration.spfxLocalWorkbench.group.storybook.title": "Storybook",
   "configuration.spfxLocalWorkbench.storybook.port.description": "Port for the Storybook dev server",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "SPFx Local Workbench",
+  "displayName": "SPFx Local Workbench!",
   "description": "A Local Workbench for testing SharePoint Framework (SPFx) web parts without deploying to SharePoint",
 
   "icons.fluentui-testbeaker.description": "Test beaker",

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spfx-local-workbench/shared",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spfx-local-workbench/shared",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.0.0"

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spfx-local-workbench/shared",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spfx-local-workbench/shared",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfx-local-workbench/shared",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Shared code for SPFx Local Workbench extension and Storybook addon",
   "author": {
     "name": "Chris Kent",

--- a/packages/shared/src/constants/HTML_FIELD_SECURITY.ts
+++ b/packages/shared/src/constants/HTML_FIELD_SECURITY.ts
@@ -1,0 +1,49 @@
+/**
+ * The default list of domains allowed to be iframed, mirroring SharePoint's built-in HTML Field Security allow-list.
+ *
+ * Each entry covers both the bare domain and all subdomains when used with `buildFrameSrc`.
+ * For example, `youtube.com` covers both `https://youtube.com` and `https://www.youtube.com`, matching SharePoint's domain-entry semantics.
+ * HTTPS is implied for all entries, as SharePoint only allows secure iframes.
+ * Maintained here AND in the primary package.json for the extension (required here for standalone usage in storybook-addon)
+ */
+export const DEFAULT_HTML_FIELD_SECURITY_DOMAINS: string[] = [
+  'youtube.com',
+  'youtube-nocookie.com',
+  'player.vimeo.com',
+  'bing.com',
+  'office.microsoft.com',
+  'officeclient.microsoft.com',
+  'store.office.com',
+  'skydrive.live.com',
+  'powerbi.com',
+  'powerbigov.us',
+  'sway.com',
+  'docs.com',
+  'powerapps.com',
+  'flow.microsoft.com',
+  'powerapps.us',
+  'flow.microsoft.us',
+  'app.smartsheet.com',
+  'publish.smartsheet.com',
+  'www.slideshare.net',
+  'youtu.be',
+  'read.amazon.com',
+  'onedrive.live.com',
+  'www.microsoft.com',
+  'forms.office365.us',
+  'support.office.com',
+  'embed.ted.com',
+  'channel9.msdn.com',
+  'forms.office.com',
+  'videoplayercdn.osi.office.net',
+  'forms.microsoft.com',
+  'forms.osi.office365.us',
+  'sway.office.com',
+  'sway.cloud.microsoft',
+  'linkedin.com',
+  'web.yammer.com',
+  'customervoice.microsoft.com',
+  'loop.usercontent.microsoft',
+  'outlook.office365.com',
+  'engage.cloud.microsoft',
+];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -5,3 +5,4 @@ export * from './DisplayMode';
 export * from './timing';
 export * from './ports';
 export * from './LOCALE_CASING_MAP';
+export * from './HTML_FIELD_SECURITY';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,6 +35,9 @@ export type {
 } from './proxy/types';
 export type { BodyFileLoader } from './proxy/MockRuleEngine';
 export * from './types';
+export { type IHtmlFieldSecurityConfig } from './types/IHtmlFieldSecurityConfig';
 export * from './utils';
+export { buildFrameSrc } from './utils/buildFrameSrc';
+export { DEFAULT_HTML_FIELD_SECURITY_DOMAINS } from './constants/HTML_FIELD_SECURITY';
 // Note: Node.js-only utils (localize, securityUtils) are in utils/node/
 // Import from '@spfx-local-workbench/shared/utils/node'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,7 +37,5 @@ export type { BodyFileLoader } from './proxy/MockRuleEngine';
 export * from './types';
 export { type IHtmlFieldSecurityConfig } from './types/IHtmlFieldSecurityConfig';
 export * from './utils';
-export { buildFrameSrc } from './utils/buildFrameSrc';
-export { DEFAULT_HTML_FIELD_SECURITY_DOMAINS } from './constants/HTML_FIELD_SECURITY';
 // Note: Node.js-only utils (localize, securityUtils) are in utils/node/
 // Import from '@spfx-local-workbench/shared/utils/node'

--- a/packages/shared/src/types/IHtmlFieldSecurityConfig.ts
+++ b/packages/shared/src/types/IHtmlFieldSecurityConfig.ts
@@ -1,0 +1,13 @@
+/** Controls which external domains are allowed to be iframed, mirroring SharePoint's HTML Field Security setting. */
+export interface IHtmlFieldSecurityConfig {
+  /**
+   * Policy mode:
+   * - `'none'` — no external iframes allowed (only the serve URL)
+   * - `'allowAll'` — all domains allowed (`frame-src *`)
+   * - `'allowList'` — only domains in `allowedDomains` are allowed (SharePoint default)
+   */
+  policy: 'none' | 'allowAll' | 'allowList';
+
+  /** Domains allowed when `policy` is `'allowList'`. Each entry covers both the bare domain and all subdomains (`https://*.domain`). */
+  allowedDomains: string[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,6 +2,7 @@
 export * from './manifests';
 export * from './components';
 export * from './amd';
+export * from './IHtmlFieldSecurityConfig';
 
 // Legacy flat exports (kept for backwards compatibility)
 export * from './ILocalizedString';

--- a/packages/shared/src/utils/buildFrameSrc.ts
+++ b/packages/shared/src/utils/buildFrameSrc.ts
@@ -1,0 +1,33 @@
+import type { IHtmlFieldSecurityConfig } from '../types/IHtmlFieldSecurityConfig';
+
+/**
+ * Builds the `frame-src` CSP source list for a given HTML field security configuration.
+ *
+ * Each domain in the allow-list expands to both `https://{domain}` and `https://*.{domain}`
+ * so that e.g. `youtube.com` covers `https://youtube.com` and `https://www.youtube.com`,
+ * matching SharePoint's domain-entry semantics.
+ *
+ * @param serveUrl The serve URL that is always allowed (e.g. `https://localhost:4321`). Pass an empty string if not applicable.
+ * @param security The HTML field security configuration. Defaults to `allowList` with an empty domain list if omitted.
+ */
+export function buildFrameSrc(
+  serveUrl: string,
+  security: IHtmlFieldSecurityConfig | undefined,
+): string {
+  const policy = security?.policy ?? 'allowList';
+
+  if (policy === 'allowAll') {
+    return serveUrl ? `${serveUrl} *` : '*';
+  }
+
+  if (policy === 'none' || !security?.allowedDomains.length) {
+    return serveUrl || "'none'";
+  }
+
+  // allowList: expand each domain to bare + wildcard subdomain
+  const domainSources = security.allowedDomains
+    .flatMap((d) => [`https://${d}`, `https://*.${d}`])
+    .join(' ');
+
+  return serveUrl ? `${serveUrl} ${domainSources}` : domainSources;
+}

--- a/packages/shared/src/utils/buildFrameSrc.ts
+++ b/packages/shared/src/utils/buildFrameSrc.ts
@@ -1,33 +1,56 @@
 import type { IHtmlFieldSecurityConfig } from '../types/IHtmlFieldSecurityConfig';
 
+const HOSTNAME_PATTERN =
+  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/;
+
+function normalizeAllowedDomains(allowedDomains: string[] | undefined): string[] {
+  if (!allowedDomains?.length) {
+    return [];
+  }
+
+  const normalizedDomains = allowedDomains
+    .map((domain) => domain.trim().toLowerCase())
+    .filter((domain) => HOSTNAME_PATTERN.test(domain));
+
+  return [...new Set(normalizedDomains)];
+}
+
 /**
  * Builds the `frame-src` CSP source list for a given HTML field security configuration.
+ *
+ * An optional baseline CSP source expression may be supplied to always allow that source,
+ * such as a local dev server origin or `'self'`.
  *
  * Each domain in the allow-list expands to both `https://{domain}` and `https://*.{domain}`
  * so that e.g. `youtube.com` covers `https://youtube.com` and `https://www.youtube.com`,
  * matching SharePoint's domain-entry semantics.
+ * Invalid allow-list entries are ignored.
  *
- * @param serveUrl The serve URL that is always allowed (e.g. `https://localhost:4321`). Pass an empty string if not applicable.
+ * @param alwaysAllowedSource CSP source expression that is always allowed (e.g. `https://localhost:4321` or `'self'`). Pass an empty string if not applicable.
  * @param security The HTML field security configuration. Defaults to `allowList` with an empty domain list if omitted.
  */
 export function buildFrameSrc(
-  serveUrl: string,
+  alwaysAllowedSource: string,
   security: IHtmlFieldSecurityConfig | undefined,
 ): string {
   const policy = security?.policy ?? 'allowList';
 
   if (policy === 'allowAll') {
-    return serveUrl ? `${serveUrl} *` : '*';
+    return alwaysAllowedSource ? `${alwaysAllowedSource} *` : '*';
   }
 
   if (policy === 'none' || !security?.allowedDomains.length) {
-    return serveUrl || "'none'";
+    return alwaysAllowedSource || "'none'";
+  }
+
+  const allowedDomains = normalizeAllowedDomains(security.allowedDomains);
+
+  if (!allowedDomains.length) {
+    return alwaysAllowedSource || "'none'";
   }
 
   // allowList: expand each domain to bare + wildcard subdomain
-  const domainSources = security.allowedDomains
-    .flatMap((d) => [`https://${d}`, `https://*.${d}`])
-    .join(' ');
+  const domainSources = allowedDomains.flatMap((d) => [`https://${d}`, `https://*.${d}`]).join(' ');
 
-  return serveUrl ? `${serveUrl} ${domainSources}` : domainSources;
+  return alwaysAllowedSource ? `${alwaysAllowedSource} ${domainSources}` : domainSources;
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,5 +1,6 @@
 // Browser-compatible utilities
 export * from './buildFluentTheme';
+export * from './buildFrameSrc';
 export * from './buildThemeList';
 export * from './componentUtils';
 export * from './deepMerge';

--- a/packages/storybook-addon-spfx/package-lock.json
+++ b/packages/storybook-addon-spfx/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@spfx-local-workbench/storybook-addon-spfx",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spfx-local-workbench/storybook-addon-spfx",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@spfx-local-workbench/shared": "^0.1.0"
+        "@spfx-local-workbench/shared": "^0.1.3"
       },
       "devDependencies": {
         "@storybook/addon-toolbars": "^8.0.0",
@@ -43,7 +43,7 @@
     },
     "../shared": {
       "name": "@spfx-local-workbench/shared",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.0.0"

--- a/packages/storybook-addon-spfx/package-lock.json
+++ b/packages/storybook-addon-spfx/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@spfx-local-workbench/storybook-addon-spfx",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spfx-local-workbench/storybook-addon-spfx",
-      "version": "1.0.0",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@spfx-local-workbench/shared": "file:../shared"
+        "@spfx-local-workbench/shared": "^0.1.0"
       },
       "devDependencies": {
         "@storybook/addon-toolbars": "^8.0.0",
@@ -42,7 +43,7 @@
     },
     "../shared": {
       "name": "@spfx-local-workbench/shared",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.0.0"

--- a/packages/storybook-addon-spfx/package.json
+++ b/packages/storybook-addon-spfx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfx-local-workbench/storybook-addon-spfx",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Storybook addon for SharePoint Framework components",
   "author": {
     "name": "Chris Kent",
@@ -62,7 +62,7 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@spfx-local-workbench/shared": "^0.1.0"
+    "@spfx-local-workbench/shared": "^0.1.3"
   },
   "devDependencies": {
     "@storybook/addon-toolbars": "^8.0.0",

--- a/packages/storybook-addon-spfx/src/constants.ts
+++ b/packages/storybook-addon-spfx/src/constants.ts
@@ -35,4 +35,11 @@ export const STORYBOOK_GLOBAL_KEYS = {
   PROXY_FALLBACK_STATUS: `${PARAM_KEY}ProxyFallbackStatus`,
   /** Set by the VS Code extension from `spfxLocalWorkbench.proxy.mode`. Defaults to `'mock'`. */
   PROXY_MODE: `${PARAM_KEY}ProxyMode`,
+  /**
+   * HTML Field Security configuration. Controls which external domains web parts may iframe.
+   * Mirrors SharePoint's built-in HTML Field Security setting.
+   * Set by the VS Code extension from `spfxLocalWorkbench.htmlFieldSecurity.*`.
+   * Falls back to `allowList` with SharePoint's default domain list when running outside the extension.
+   */
+  HTML_FIELD_SECURITY: `${PARAM_KEY}HtmlFieldSecurity`,
 } as const;

--- a/packages/storybook-addon-spfx/src/decorators/withSpfx.tsx
+++ b/packages/storybook-addon-spfx/src/decorators/withSpfx.tsx
@@ -5,13 +5,16 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import {
   BrowserProxyTransport,
+  DEFAULT_HTML_FIELD_SECURITY_DOMAINS,
   DEFAULT_THEME_NAME,
+  type IHtmlFieldSecurityConfig,
   type ITheme,
   type IWebPartManifest,
   ProxyAadHttpClient,
   ProxyHttpClient,
   ProxySPHttpClient,
   StatusRenderer,
+  buildFrameSrc,
   buildMockPageContext,
   buildThemeList,
   installFetchInterceptor,
@@ -146,6 +149,10 @@ export const withSpfx: Decorator = (Story, context: StoryContext) => {
   const globalProxyMode: 'mock' | 'mock-passthrough' =
     rawGlobalProxyMode === 'mock-passthrough' ? 'mock-passthrough' : 'mock';
   const proxyMode = parameters.proxy?.mode ?? globalProxyMode;
+  // HTML field security: VS Code global setting → default allowList with SharePoint domains
+  const htmlFieldSecurity: IHtmlFieldSecurityConfig = globals[
+    STORYBOOK_GLOBAL_KEYS.HTML_FIELD_SECURITY
+  ] ?? { policy: 'allowList', allowedDomains: DEFAULT_HTML_FIELD_SECURITY_DOMAINS };
 
   // Initialize proxy transport when proxy is enabled (or when config changes between stories)
   useEffect(() => {
@@ -420,10 +427,25 @@ export const withSpfx: Decorator = (Story, context: StoryContext) => {
           }
         }
 
+        // Enforce HTML field security before rendering: inject a Content-Security-Policy
+        // meta tag into the preview iframe's <head> that restricts which external domains
+        // web parts may iframe. This mirrors SharePoint's HTML Field Security setting so
+        // Storybook gives developers the same signal as the real SharePoint environment.
+        // The meta tag is id-keyed so repeated renders replace rather than accumulate entries.
+        const frameSrc = buildFrameSrc('', htmlFieldSecurity);
+        const cspMetaId = 'spfx-iframe-csp';
+        let cspMeta = document.getElementById(cspMetaId) as HTMLMetaElement | null;
+        if (!cspMeta) {
+          cspMeta = document.createElement('meta');
+          cspMeta.id = cspMetaId;
+          cspMeta.httpEquiv = 'Content-Security-Policy';
+          document.head.appendChild(cspMeta);
+        }
+        cspMeta.content = `frame-src ${frameSrc}`;
+
         // Render the component — theme is already applied above.
         instance.render();
 
-        // Emit property changes when they happen
         if (instance.onPropertyPaneFieldChanged) {
           const originalHandler = instance.onPropertyPaneFieldChanged.bind(instance);
           instance.onPropertyPaneFieldChanged = (
@@ -494,8 +516,16 @@ export const withSpfx: Decorator = (Story, context: StoryContext) => {
     if (instance._context) {
       instance._context.displayMode = displayMode;
     }
+
+    // Re-apply the CSP meta tag in case the security config changed between renders
+    const updatedFrameSrc = buildFrameSrc('', htmlFieldSecurity);
+    const existingMeta = document.getElementById('spfx-iframe-csp') as HTMLMetaElement | null;
+    if (existingMeta) {
+      existingMeta.content = `frame-src ${updatedFrameSrc}`;
+    }
+
     instance.render();
-  }, [properties, displayMode, themeName, locale]);
+  }, [properties, displayMode, themeName, locale, htmlFieldSecurity]);
 
   return (
     <SpfxContextProvider

--- a/packages/storybook-addon-spfx/src/decorators/withSpfx.tsx
+++ b/packages/storybook-addon-spfx/src/decorators/withSpfx.tsx
@@ -432,7 +432,7 @@ export const withSpfx: Decorator = (Story, context: StoryContext) => {
         // web parts may iframe. This mirrors SharePoint's HTML Field Security setting so
         // Storybook gives developers the same signal as the real SharePoint environment.
         // The meta tag is id-keyed so repeated renders replace rather than accumulate entries.
-        const frameSrc = buildFrameSrc('', htmlFieldSecurity);
+        const frameSrc = buildFrameSrc("'self'", htmlFieldSecurity);
         const cspMetaId = 'spfx-iframe-csp';
         let cspMeta = document.getElementById(cspMetaId) as HTMLMetaElement | null;
         if (!cspMeta) {
@@ -518,7 +518,7 @@ export const withSpfx: Decorator = (Story, context: StoryContext) => {
     }
 
     // Re-apply the CSP meta tag in case the security config changed between renders
-    const updatedFrameSrc = buildFrameSrc('', htmlFieldSecurity);
+    const updatedFrameSrc = buildFrameSrc("'self'", htmlFieldSecurity);
     const existingMeta = document.getElementById('spfx-iframe-csp') as HTMLMetaElement | null;
     if (existingMeta) {
       existingMeta.content = `frame-src ${updatedFrameSrc}`;

--- a/packages/storybook-addon-spfx/src/preview.ts
+++ b/packages/storybook-addon-spfx/src/preview.ts
@@ -2,7 +2,10 @@
  * Storybook preview configuration for SPFx addon
  * This file is loaded in the preview iframe and provides decorators
  */
-import { DEFAULT_THEME_NAME } from '@spfx-local-workbench/shared';
+import {
+  DEFAULT_HTML_FIELD_SECURITY_DOMAINS,
+  DEFAULT_THEME_NAME,
+} from '@spfx-local-workbench/shared';
 
 import { DisplayMode, STORYBOOK_GLOBAL_KEYS } from './constants';
 import { withSpfx } from './decorators/withSpfx';
@@ -18,6 +21,9 @@ export const globalTypes = {
   },
   [STORYBOOK_GLOBAL_KEYS.THEME]: {
     defaultValue: DEFAULT_THEME_NAME,
+  },
+  [STORYBOOK_GLOBAL_KEYS.HTML_FIELD_SECURITY]: {
+    defaultValue: { policy: 'allowList', allowedDomains: DEFAULT_HTML_FIELD_SECURITY_DOMAINS },
   },
 };
 

--- a/scripts/block-root-publish.mjs
+++ b/scripts/block-root-publish.mjs
@@ -1,0 +1,2 @@
+console.error('Publishing the repo root to npm is disabled. Use "npm run packages:publish" to publish the package manifests under packages/.');
+process.exit(1);

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const packageDirectories = [
+  path.join(repoRoot, 'packages', 'shared'),
+  path.join(repoRoot, 'packages', 'storybook-addon-spfx')
+];
+
+const extraArgs = process.argv.slice(2);
+
+for (const packageDirectory of packageDirectories) {
+  const result = spawnSync('npm', ['publish', '--access', 'public', ...extraArgs], {
+    cwd: packageDirectory,
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/sync-package-versions.mjs
+++ b/scripts/sync-package-versions.mjs
@@ -1,0 +1,96 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const rootPackagePath = path.join(repoRoot, 'package.json');
+const sharedPackagePath = path.join(repoRoot, 'packages', 'shared', 'package.json');
+const addonPackagePath = path.join(repoRoot, 'packages', 'storybook-addon-spfx', 'package.json');
+const sharedPackageName = '@spfx-local-workbench/shared';
+
+const checkOnly = process.argv.includes('--check');
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function replaceVersion(versionRange, version) {
+  if (!versionRange) {
+    return version;
+  }
+
+  const match = versionRange.match(/^([^0-9]*)(.+)$/);
+  if (!match) {
+    return version;
+  }
+
+  return `${match[1]}${version}`;
+}
+
+const rootPackage = readJson(rootPackagePath);
+const sharedPackage = readJson(sharedPackagePath);
+const addonPackage = readJson(addonPackagePath);
+
+if (!rootPackage.version) {
+  throw new Error('Root package.json does not define a version.');
+}
+
+const expectedVersion = rootPackage.version;
+const currentSharedDependency = addonPackage.dependencies?.[sharedPackageName];
+const expectedSharedDependency = replaceVersion(currentSharedDependency, expectedVersion);
+
+const mismatches = [];
+
+if (sharedPackage.version !== expectedVersion) {
+  mismatches.push(`packages/shared version is ${sharedPackage.version}; expected ${expectedVersion}`);
+}
+
+if (addonPackage.version !== expectedVersion) {
+  mismatches.push(`packages/storybook-addon-spfx version is ${addonPackage.version}; expected ${expectedVersion}`);
+}
+
+if (currentSharedDependency !== expectedSharedDependency) {
+  mismatches.push(
+    `packages/storybook-addon-spfx dependency on ${sharedPackageName} is ${currentSharedDependency}; expected ${expectedSharedDependency}`
+  );
+}
+
+if (checkOnly) {
+  if (mismatches.length > 0) {
+    console.error('Package version sync check failed:');
+    for (const mismatch of mismatches) {
+      console.error(`- ${mismatch}`);
+    }
+
+    process.exitCode = 1;
+  } else {
+    console.log(`Package versions already match root version ${expectedVersion}.`);
+  }
+
+  process.exit();
+}
+
+sharedPackage.version = expectedVersion;
+addonPackage.version = expectedVersion;
+
+addonPackage.dependencies ??= {};
+addonPackage.dependencies[sharedPackageName] = expectedSharedDependency;
+
+writeJson(sharedPackagePath, sharedPackage);
+writeJson(addonPackagePath, addonPackage);
+
+if (mismatches.length > 0) {
+  console.log(`Synchronized package versions to ${expectedVersion}.`);
+  for (const mismatch of mismatches) {
+    console.log(`- ${mismatch}`);
+  }
+} else {
+  console.log(`Package versions already matched ${expectedVersion}. Rewrote manifests with normalized formatting.`);
+}

--- a/src/workbench/WorkbenchPanel.ts
+++ b/src/workbench/WorkbenchPanel.ts
@@ -43,6 +43,9 @@ export class WorkbenchPanel {
   private _lastProxyEnabled: boolean = vscode.workspace
     .getConfiguration('spfxLocalWorkbench.proxy')
     .get<boolean>('enabled', true);
+  private _lastHtmlFieldSecurityKey: string = JSON.stringify(
+    getWorkbenchSettings().htmlFieldSecurity,
+  );
   private _displayMode: DisplayMode = DisplayMode.Edit;
   private _preservedComponentConfigs: any[] | undefined;
 
@@ -179,6 +182,14 @@ export class WorkbenchPanel {
       onConfigurationChanged((newSettings) => {
         this._settings = newSettings;
         const currentTheme = getCurrentTheme();
+
+        // The htmlFieldSecurity setting changes the CSP baked into the HTML at load time.
+        const securityKey = JSON.stringify(newSettings.htmlFieldSecurity);
+        if (securityKey !== this._lastHtmlFieldSecurityKey) {
+          this._lastHtmlFieldSecurityKey = securityKey;
+          this._update();
+          return;
+        }
 
         // The proxy.enabled setting changes CSP, HTTP client classes, and bridge initialization — all baked into the HTML at load time.
         const proxyNow = vscode.workspace
@@ -436,6 +447,7 @@ export class WorkbenchPanel {
       proxyEnabled: this._apiProxyService?.enabled ?? true,
       propertyPaneShrinkCanvas: this._settings.propertyPaneShrinkCanvas,
       externalDependencies: this._externalDependencies,
+      htmlFieldSecurity: this._settings.htmlFieldSecurity,
     });
   }
 

--- a/src/workbench/config/WorkbenchConfig.ts
+++ b/src/workbench/config/WorkbenchConfig.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import {
   DEFAULT_PAGE_CONTEXT,
   DEFAULT_THEME_NAME,
+  type IHtmlFieldSecurityConfig,
   type IPageContextConfig,
   type ITheme,
   MICROSOFT_THEMES,
@@ -26,6 +27,7 @@ export interface IWorkbenchSettings {
   serveCommand: string;
   context: IContextConfig;
   propertyPaneShrinkCanvas: boolean;
+  htmlFieldSecurity: IHtmlFieldSecurityConfig;
 }
 
 // Default configuration values
@@ -37,6 +39,11 @@ const defaults = {
     pageContext: DEFAULT_PAGE_CONTEXT,
   },
   propertyPaneShrinkCanvas: true,
+  htmlFieldSecurity: {
+    // VS Code always provides the package.json default; this fallback is never reached in practice
+    policy: 'allowList' as const,
+    allowedDomains: [] as string[],
+  },
 };
 
 // Gets the current workbench configuration from VS Code settings
@@ -60,6 +67,16 @@ export function getWorkbenchSettings(): IWorkbenchSettings {
       'propertyPane.shrinkCanvas',
       defaults.propertyPaneShrinkCanvas,
     ),
+    htmlFieldSecurity: {
+      policy: config.get<'none' | 'allowAll' | 'allowList'>(
+        'htmlFieldSecurity.policy',
+        defaults.htmlFieldSecurity.policy,
+      ),
+      allowedDomains: config.get<string[]>(
+        'htmlFieldSecurity.allowedDomains',
+        defaults.htmlFieldSecurity.allowedDomains,
+      ),
+    },
   };
 }
 

--- a/src/workbench/html/WorkbenchHtmlGenerator.ts
+++ b/src/workbench/html/WorkbenchHtmlGenerator.ts
@@ -3,7 +3,11 @@
 // This module generates the complete HTML for the workbench webview.
 import * as vscode from 'vscode';
 
-import type { ITheme } from '@spfx-local-workbench/shared';
+import {
+  type IHtmlFieldSecurityConfig,
+  type ITheme,
+  buildFrameSrc,
+} from '@spfx-local-workbench/shared';
 
 import type { IExternalDependency } from '../SpfxProjectDetector';
 import type { IContextConfig } from '../config/WorkbenchConfig';
@@ -33,6 +37,8 @@ export interface IHtmlGeneratorConfig {
   propertyPaneShrinkCanvas?: boolean;
   // External dependencies resolved from the SPFx project's node_modules
   externalDependencies?: IExternalDependency[];
+  // HTML field security configuration controlling which external domains web parts may iframe
+  htmlFieldSecurity?: IHtmlFieldSecurityConfig;
 }
 
 // Generates the Content Security Policy for the webview
@@ -46,7 +52,7 @@ function generateCsp(config: IHtmlGeneratorConfig): string {
     `connect-src ${config.serveUrl} https://*.sharepoint.com https://login.windows.net`,
     `img-src ${config.cspSource} ${config.serveUrl} https: data:`,
     `font-src ${config.cspSource} ${config.serveUrl} https: data:`,
-    `frame-src ${config.serveUrl}`,
+    `frame-src ${buildFrameSrc(config.serveUrl, config.htmlFieldSecurity)}`,
   ].join('; ');
 }
 

--- a/src/workbench/storybook/StorybookPanel.ts
+++ b/src/workbench/storybook/StorybookPanel.ts
@@ -398,7 +398,7 @@ export class StorybookPanel {
     </style>
 </head>
 <body>
-    <iframe id="storybook-frame" src="${storybookUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"></iframe>
+    <iframe id="storybook-frame" src="${storybookUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals" allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"></iframe>
     <div id="spfx-cm-backdrop"></div>
     <div id="spfx-cm" role="menu">
       <div class="cm-item" role="menuitem" tabindex="-1" id="cm-undo">      <span>Undo</span>       <span class="cm-hint" id="hint-undo"></span></div>

--- a/src/workbench/storybook/StorybookServerManager.ts
+++ b/src/workbench/storybook/StorybookServerManager.ts
@@ -313,7 +313,13 @@ export class StorybookServerManager {
     const proxyMode = vscode.workspace
       .getConfiguration('spfxLocalWorkbench.proxy')
       .get<string>('mode', 'mock');
-    previewConfig += `\n// Injected by VS Code extension at startup\nexport const globals = {\n  spfxTheme: ${JSON.stringify(defaultThemeName)},\n  spfxCustomThemes: ${JSON.stringify(customThemes)},\n  spfxProxyEnabled: ${JSON.stringify(proxyEnabled)},\n  spfxProxyFallbackStatus: ${JSON.stringify(proxyFallbackStatus)},\n  spfxProxyMode: ${JSON.stringify(proxyMode)},\n};\n`;
+    const htmlFieldSecurityPolicy = vscode.workspace
+      .getConfiguration('spfxLocalWorkbench')
+      .get<string>('htmlFieldSecurity.policy', 'allowList');
+    const htmlFieldSecurityDomains = vscode.workspace
+      .getConfiguration('spfxLocalWorkbench')
+      .get<string[]>('htmlFieldSecurity.allowedDomains', []);
+    previewConfig += `\n// Injected by VS Code extension at startup\nexport const globals = {\n  spfxTheme: ${JSON.stringify(defaultThemeName)},\n  spfxCustomThemes: ${JSON.stringify(customThemes)},\n  spfxProxyEnabled: ${JSON.stringify(proxyEnabled)},\n  spfxProxyFallbackStatus: ${JSON.stringify(proxyFallbackStatus)},\n  spfxProxyMode: ${JSON.stringify(proxyMode)},\n  spfxHtmlFieldSecurity: ${JSON.stringify({ policy: htmlFieldSecurityPolicy, allowedDomains: htmlFieldSecurityDomains })},\n};\n`;
 
     await vscode.workspace.fs.writeFile(
       vscode.Uri.file(previewTs),


### PR DESCRIPTION
This is mostly to match the default HTML Field Security policies and settings of SharePoint to mirror that experience. It also has config settings so that anyone with a non-default setup in SharePoint can still mirror that experience. But there are some complications with sites like YouTube (see README for details) that can only be overcome by changing from a direct HTML in webview approach to a local hosted webview. This is why it works in Storybook, but that's a pretty big change just to get embedded YouTube to work, so leaving it as a limitation for now.

I also added some publishing scripts. I accidentally published the main extension to npmjs (since removed) so added private and a prepublish script to prevent that. Currently the setup synchronizes the version of the packages with the version of the extension, but I think that's likely a mistake going forward. Leaving for now to be reconsidered on our next publish.

---
This pull request introduces configurable HTML Field Security settings to the extension, mirroring SharePoint's iframe embedding security model. It adds new configuration options, utilities, and constants for managing allowed iframe domains, and updates documentation and package metadata to reflect these changes and new publishing workflows.

**HTML Field Security Configuration:**

* Added new settings to `package.json` for `spfxLocalWorkbench.htmlFieldSecurity.policy` (with modes: `none`, `allowAll`, `allowList`) and `spfxLocalWorkbench.htmlFieldSecurity.allowedDomains`, defaulting to a list matching SharePoint's HTML Field Security allow-list.
* Introduced the `IHtmlFieldSecurityConfig` type, `DEFAULT_HTML_FIELD_SECURITY_DOMAINS` constant, and a utility function `buildFrameSrc` for generating the correct CSP `frame-src` value based on configuration. [[1]](diffhunk://#diff-912bd3156706295337aee2803d26f6089efe6f46d9fa9643b5a58c12e2f6b797R1-R13) [[2]](diffhunk://#diff-de63e440af1c068a6541ba9ba4325c833ea4f484a1b21debe3a02b4a808c1afeR1-R49) [[3]](diffhunk://#diff-49371f05ccd48337276f339fcd40cae5ef3e208f46a23b661b936bf1dee541b3R1-R33) [[4]](diffhunk://#diff-166dedc3509c371dc66ffbbaf49c0d4e782134e386611110a73979f96233ecd3R8) [[5]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR38-R41) [[6]](diffhunk://#diff-43b22797af0cdf77adb47b4b1a2145191d4007a15da3b198b5ac364bdc811c24R5) [[7]](diffhunk://#diff-35d645f5c8f550d60b305ffb1713b460aca0ecac182b18acefc8c6a47282e1bcR3)
* Added localized descriptions for the new settings in both English and French NLS files. [[1]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0R117-R121) [[2]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5R116-R120)

**Publishing and Package Management:**

* Updated `CONTRIBUTING.md` with detailed instructions and scripts for versioning and publishing both the extension and its packages, and added corresponding scripts to `package.json`. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R12-R60) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R858-R862) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R871) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R839)
* Marked the root package as `private` and changed package name/publisher to `pnp-spfx-local-workbench`/`m365pnp`. Updated versions in root and shared package manifests. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R7) [[2]](diffhunk://#diff-3752b1e4e3e2032593e21e9268ec0379680a59e4e7b8517d0d5492a71530d3e8L3-R3) [[3]](diffhunk://#diff-f556308f11ae4a257705f08bc768cfa16de6d1876cee7132f17944c999645119L3-R9)

**Documentation and Troubleshooting:**

* Added a troubleshooting section explaining why YouTube and other video embeds may fail in the local workbench due to browser security policies, with suggested workarounds.
* Updated `.vscodeignore` to exclude additional files and added documentation about the new publishing workflow.

**Miscellaneous:**

* Added new keywords to `package.json` to improve discoverability.
* Minor updates to display names in NLS files. [[1]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L2-R2) [[2]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L2-R2)